### PR TITLE
Freeze trace schema v0.1 (schemas/trace-0.1.json)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 build/
 dist/
 .venv/
+.venv-dev/
 venv/
 env/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Issues = "https://github.com/yeongseon/azure-functions-runtime-visualizer/issues
 funcviz = "funcviz.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "ruff>=0.6"]
+dev = ["pytest>=8", "ruff>=0.6", "jsonschema>=4"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/funcviz"]

--- a/schemas/examples/success.example.json
+++ b/schemas/examples/success.example.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "0.1",
+  "traceId": "success-001",
+  "outcome": "success",
+  "input": { "source": "core-tools-log", "adapter": "CoreToolsLogAdapter", "adapterVersion": "0.1" },
+  "runtime": {
+    "environment": "local",
+    "language": "python",
+    "trigger": "http",
+    "coreToolsVersion": "TBD",
+    "hostVersion": "TBD"
+  },
+  "application": {
+    "functionName": "hello",
+    "sourceFile": "function_app.py",
+    "sourceText": "import azure.functions as func\n\napp = func.FunctionApp()\n\n@app.route(route=\"hello\")\ndef hello(req: func.HttpRequest) -> func.HttpResponse:\n    name = req.params.get(\"name\") or \"Azure\"\n    return func.HttpResponse(f\"Hello, {name}!\")\n",
+    "definitionLineRange": [5, 8]
+  },
+  "lanes": {
+    "client":        { "status": "reached", "confidence": "inferred", "reason": "Derived from host HTTP request/response lines." },
+    "host":          { "status": "reached", "confidence": "observed" },
+    "python-worker": { "status": "reached", "confidence": "observed" },
+    "application":   { "status": "reached", "confidence": "inferred", "reason": "User-code entry/exit is not separately logged." }
+  },
+  "events": [
+    {
+      "id": "e0", "sequence": 0, "timestamp": "2026-09-05T00:45:16.955Z", "elapsedMs": 0,
+      "lane": "client", "event": "HttpRequestReceived",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:16.955Z] Executing HTTP request: { \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\", ... }"
+    },
+    {
+      "id": "e1", "sequence": 1, "timestamp": "2026-09-05T00:45:17.206Z", "elapsedMs": 251,
+      "lane": "host", "event": "InvocationStarted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='...', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)"
+    },
+    {
+      "id": "e2", "sequence": 2, "timestamp": "2026-09-05T00:45:17.227Z", "elapsedMs": 272,
+      "lane": "python-worker", "event": "WorkerReceivedInvocation",
+      "workerRequestId": "e42785bf-7670-4de1-a81d-b05df7b2b32d",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.227Z] Received FunctionInvocationRequest, request ID: e42785bf-..., invocation ID: 6a8f3658-..."
+    },
+    {
+      "id": "e3", "sequence": 3, "timestamp": "2026-09-05T00:45:17.240Z", "elapsedMs": 285,
+      "lane": "host", "event": "InvocationCompleted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Succeeded, Id=6a8f3658-..., Duration=54ms)"
+    },
+    {
+      "id": "e4", "sequence": 4, "timestamp": "2026-09-05T00:45:17.249Z", "elapsedMs": 294,
+      "lane": "client", "event": "HttpResponseReturned",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:17.249Z] Executed HTTP request: { \"requestId\": \"2d0db691-...\", \"status\": \"200\", \"duration\": \"294\" }"
+    }
+  ],
+  "intervals": [
+    {
+      "id": "i1", "label": "Invocation (host log delta)", "lane": "host", "kind": "invocation",
+      "startEvent": "e1", "endEvent": "e3", "durationMs": 34, "source": "log-delta", "confidence": "observed"
+    },
+    {
+      "id": "i2", "label": "Invocation (host-reported)", "lane": "host", "kind": "invocation",
+      "startEvent": "e1", "endEvent": "e3", "durationMs": 54, "source": "host-reported", "confidence": "observed",
+      "raw": "Duration=54ms"
+    },
+    {
+      "id": "i3", "label": "HTTP request", "lane": "client", "kind": "http",
+      "startEvent": "e0", "endEvent": "e4", "durationMs": 294, "source": "http-reported", "confidence": "inferred",
+      "raw": "\"duration\": \"294\""
+    }
+  ],
+  "failures": [],
+  "metadata": {}
+}

--- a/schemas/examples/worker-fail.example.json
+++ b/schemas/examples/worker-fail.example.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "0.1",
+  "traceId": "worker-fail-001",
+  "outcome": "failure",
+  "input": { "source": "core-tools-log", "adapter": "CoreToolsLogAdapter", "adapterVersion": "0.1" },
+  "runtime": {
+    "environment": "local",
+    "language": "python",
+    "trigger": "http",
+    "coreToolsVersion": "TBD",
+    "hostVersion": "TBD"
+  },
+  "application": {
+    "functionName": "hello",
+    "sourceFile": "function_app.py"
+  },
+  "lanes": {
+    "client":        { "status": "not-reached", "confidence": "observed", "reason": "No HTTP request was served; the worker failed to index functions before any request." },
+    "host":          { "status": "failed-here", "confidence": "observed", "failureEvent": "e2" },
+    "python-worker": { "status": "failed-here", "confidence": "observed", "failureEvent": "e1" },
+    "application":   { "status": "not-reached", "confidence": "observed", "reason": "User code never executed." }
+  },
+  "events": [
+    {
+      "id": "e0", "sequence": 0, "timestamp": "2026-09-05T00:44:10.000Z", "elapsedMs": 0,
+      "lane": "python-worker", "event": "WorkerStarting",
+      "workerRequestId": "e42785bf-7670-4de1-a81d-b05df7b2b32d",
+      "confidence": "observed",
+      "raw": "[...] Starting Azure Functions Python Worker."
+    },
+    {
+      "id": "e1", "sequence": 1, "timestamp": "2026-09-05T00:44:11.000Z", "elapsedMs": 1000,
+      "lane": "python-worker", "event": "WorkerIndexingError",
+      "confidence": "observed",
+      "attributes": { "exception": "ModuleNotFoundError" },
+      "raw": "[...] Error in index_function_app. ModuleNotFoundError: No module named 'nonexistent'"
+    },
+    {
+      "id": "e2", "sequence": 2, "timestamp": "2026-09-05T00:44:11.100Z", "elapsedMs": 1100,
+      "lane": "host", "event": "WorkerIndexingFailure",
+      "confidence": "observed",
+      "raw": "[...] Worker failed to index functions. Result: Failure"
+    }
+  ],
+  "intervals": [],
+  "failures": [
+    { "event": "e1", "kind": "worker-init", "message": "Worker failed to index functions (ModuleNotFoundError)." }
+  ],
+  "metadata": {}
+}

--- a/schemas/trace-0.1.json
+++ b/schemas/trace-0.1.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/yeongseon/azure-functions-runtime-visualizer/schemas/trace-0.1.json",
+  "title": "funcviz trace",
+  "description": "Versioned trace schema v0.1 for the Azure Functions Runtime Visualizer. Frozen per PRD §6 (post-Phase-0 redesign). Schema versioning is never-cut (PRD §11).",
+  "type": "object",
+  "additionalProperties": false,
+  "$comment": "Referential invariants JSON Schema cannot enforce, guaranteed by the parser instead: event.id values are unique; every interval.startEvent/endEvent and lanes[].failureEvent references an existing event.id; an interval's endEvent does not precede its startEvent in sequence.",
+  "required": [
+    "schemaVersion",
+    "traceId",
+    "outcome",
+    "input",
+    "runtime",
+    "lanes",
+    "events",
+    "intervals"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "0.1",
+      "description": "Frozen schema version. A trace omitting this or carrying another value is not a v0.1 trace."
+    },
+    "traceId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable id for this trace. Not derived from workerRequestId (that is a session span, not a per-trace key)."
+    },
+    "outcome": {
+      "enum": [
+        "success",
+        "failure"
+      ]
+    },
+    "input": {
+      "type": "object",
+      "description": "Which adapter produced the LogRecords the parser consumed. Extension point for v0.2 adapters.",
+      "additionalProperties": true,
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "e.g. core-tools-log, app-insights-query, otel.",
+          "minLength": 1
+        },
+        "adapter": {
+          "type": "string"
+        },
+        "adapterVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "description": "Recorded because the parser is coupled to log text; a trace without versions is not reproducible (PRD §6).",
+      "additionalProperties": false,
+      "required": [
+        "environment",
+        "language",
+        "trigger"
+      ],
+      "properties": {
+        "environment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "language": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trigger": {
+          "type": "string",
+          "minLength": 1
+        },
+        "coreToolsVersion": {
+          "type": "string"
+        },
+        "hostVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "application": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "functionName"
+      ],
+      "properties": {
+        "functionName": {
+          "type": "string"
+        },
+        "sourceFile": {
+          "type": "string"
+        },
+        "sourceText": {
+          "type": "string"
+        },
+        "definitionLineRange": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "minItems": 2,
+          "maxItems": 2,
+          "description": "[startLine, endLine], 1-based inclusive."
+        }
+      }
+    },
+    "lanes": {
+      "type": "object",
+      "description": "Per-lane status metadata. Lane population is data: an empty lane in a failure trace is a finding, rendered via status, not a blank column (FR-9.1).",
+      "additionalProperties": false,
+      "required": [
+        "client",
+        "host",
+        "python-worker",
+        "application"
+      ],
+      "properties": {
+        "client": {
+          "$ref": "#/$defs/laneStatus"
+        },
+        "host": {
+          "$ref": "#/$defs/laneStatus"
+        },
+        "python-worker": {
+          "$ref": "#/$defs/laneStatus"
+        },
+        "application": {
+          "$ref": "#/$defs/laneStatus"
+        }
+      }
+    },
+    "events": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/event"
+      }
+    },
+    "intervals": {
+      "type": "array",
+      "description": "Durations. There is no single canonical duration; each interval names its source and references events by id.",
+      "items": {
+        "$ref": "#/$defs/interval"
+      }
+    },
+    "failures": {
+      "type": "array",
+      "description": "Extension point: structured failure records referencing event ids.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "event": {
+            "type": "string",
+            "description": "Event id where the failure was observed."
+          },
+          "kind": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Free-form extension point for future adapters and tooling.",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "lane": {
+      "enum": [
+        "client",
+        "host",
+        "python-worker",
+        "application"
+      ]
+    },
+    "confidence": {
+      "enum": [
+        "observed",
+        "inferred",
+        "instrumented"
+      ],
+      "description": "instrumented is reserved but unused in v0.1."
+    },
+    "laneStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "confidence"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "reached",
+            "not-reached",
+            "failed-here",
+            "unknown"
+          ]
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "failureEvent": {
+          "type": "string",
+          "description": "Event id, required when status is failed-here."
+        }
+      },
+      "if": {
+        "properties": {
+          "status": {
+            "const": "failed-here"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "failureEvent"
+        ]
+      }
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sequence",
+        "lane",
+        "event",
+        "confidence",
+        "raw"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable id referenced by intervals/failures. Not the sequence."
+        },
+        "sequence": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "ISO 8601 with millisecond resolution when available."
+        },
+        "elapsedMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "lane": {
+          "$ref": "#/$defs/lane"
+        },
+        "event": {
+          "type": "string",
+          "minLength": 1
+        },
+        "httpRequestId": {
+          "type": "string",
+          "description": "Host HTTP pipeline id (requestId in the HTTP request/response blocks)."
+        },
+        "workerRequestId": {
+          "type": "string",
+          "description": "Worker gRPC channel/session id (Request ID:), spans the whole worker session."
+        },
+        "invocationId": {
+          "type": "string",
+          "description": "Per-invocation id (invocation ID: / Id=); shared across the Host<->Worker boundary."
+        },
+        "correlation": {
+          "type": "object",
+          "description": "Reserved escape-hatch map for identifiers a future adapter surfaces that do not map to the three named fields. Not a replacement for them.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "raw": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Original log line(s). Null only for synthesized/inferred events."
+        }
+      }
+    },
+    "interval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "lane",
+        "kind",
+        "startEvent",
+        "endEvent",
+        "durationMs",
+        "source",
+        "confidence"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "lane": {
+          "$ref": "#/$defs/lane"
+        },
+        "kind": {
+          "type": "string",
+          "description": "e.g. invocation, http, worker-startup.",
+          "minLength": 1
+        },
+        "startEvent": {
+          "type": "string",
+          "description": "Event id."
+        },
+        "endEvent": {
+          "type": "string",
+          "description": "Event id."
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "source": {
+          "enum": [
+            "log-delta",
+            "host-reported",
+            "http-reported",
+            "inferred",
+            "provider-reported"
+          ]
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "raw": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/test_schema_v0_1.py
+++ b/tests/test_schema_v0_1.py
@@ -1,0 +1,111 @@
+"""Schema-freeze tests for trace-0.1.json (issue #1, PRD §6).
+
+These lock the v0.1 trace contract: the schema must accept both shipped example
+shapes (a success trace and a worker-failure trace with unreached lanes) and
+must reject structural violations. Schema versioning is never-cut (PRD §11), so
+a change that breaks these tests should come with a schemaVersion bump.
+
+Run: pytest tests/test_schema_v0_1.py
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = ROOT / "schemas" / "trace-0.1.json"
+EXAMPLES_DIR = ROOT / "schemas" / "examples"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def validator(schema: dict) -> Draft202012Validator:
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+@pytest.fixture(scope="module")
+def success_trace() -> dict:
+    return json.loads((EXAMPLES_DIR / "success.example.json").read_text())
+
+
+def test_schema_is_itself_valid(schema: dict) -> None:
+    Draft202012Validator.check_schema(schema)
+    assert schema["properties"]["schemaVersion"]["const"] == "0.1"
+
+
+@pytest.mark.parametrize(
+    "example",
+    ["success.example.json", "worker-fail.example.json"],
+)
+def test_example_traces_validate(validator: Draft202012Validator, example: str) -> None:
+    trace = json.loads((EXAMPLES_DIR / example).read_text())
+    errors = sorted(validator.iter_errors(trace), key=str)
+    assert not errors, "\n".join(f"{list(e.path)}: {e.message}" for e in errors)
+
+
+def test_three_correlation_ids_stay_separate(success_trace: dict) -> None:
+    """The success trace must exercise all three id namespaces as distinct fields."""
+    props = json.loads(SCHEMA_PATH.read_text())["$defs"]["event"]["properties"]
+    for field in ("httpRequestId", "workerRequestId", "invocationId"):
+        assert field in props
+    ids = {e.get("invocationId") for e in success_trace["events"] if e.get("invocationId")}
+    assert ids == {"6a8f3658-2b31-4554-aa86-1ee32a9e679b"}
+
+
+def test_intervals_carry_distinct_duration_sources(success_trace: dict) -> None:
+    """No single canonical duration: the 34/54/294ms triple with explicit sources."""
+    by_source = {i["source"]: i["durationMs"] for i in success_trace["intervals"]}
+    assert by_source["log-delta"] == 34
+    assert by_source["host-reported"] == 54
+    assert by_source["http-reported"] == 294
+
+
+def test_failure_trace_marks_unreached_lanes(validator: Draft202012Validator) -> None:
+    trace = json.loads((EXAMPLES_DIR / "worker-fail.example.json").read_text())
+    assert not list(validator.iter_errors(trace))
+    assert trace["lanes"]["client"]["status"] == "not-reached"
+    assert trace["lanes"]["application"]["status"] == "not-reached"
+    assert trace["lanes"]["host"]["status"] == "failed-here"
+
+
+def _mutate(base: dict, fn) -> dict:
+    t = copy.deepcopy(base)
+    fn(t)
+    return t
+
+
+REJECTIONS = {
+    "wrong schemaVersion": lambda t: t.update(schemaVersion="0.2"),
+    "bad outcome enum": lambda t: t.update(outcome="partial"),
+    "bad lane enum": lambda t: t["events"][1].update(lane="worker"),
+    "bad confidence enum": lambda t: t["events"][1].update(confidence="guessed"),
+    "bad interval source enum": lambda t: t["intervals"][0].update(source="made-up"),
+    "bad lane status enum": lambda t: t["lanes"]["host"].update(status="done"),
+    "event missing required raw": lambda t: t["events"][1].pop("raw"),
+    "event extra property": lambda t: t["events"][1].update(surprise=1),
+    "lanes missing application": lambda t: t["lanes"].pop("application"),
+    "missing top-level lanes": lambda t: t.pop("lanes"),
+    "interval missing source": lambda t: t["intervals"][0].pop("source"),
+    "missing input": lambda t: t.pop("input"),
+    "missing intervals": lambda t: t.pop("intervals"),
+    "empty events": lambda t: t.update(events=[]),
+    "failed-here without failureEvent": lambda t: t["lanes"]["host"].update(status="failed-here"),
+}
+
+
+@pytest.mark.parametrize("label", list(REJECTIONS))
+def test_schema_rejects_violations(
+    validator: Draft202012Validator, success_trace: dict, label: str
+) -> None:
+    bad = _mutate(success_trace, REJECTIONS[label])
+    assert list(validator.iter_errors(bad)), f"schema should reject: {label}"


### PR DESCRIPTION
Closes #1.

Turns PRD §6 (post-Phase-0 redesign) into a versioned Draft 2020-12 JSON Schema, frozen as the v0.1 trace contract.

## What's in it
- **Three separate correlation IDs** on events — `httpRequestId` / `workerRequestId` / `invocationId` — never collapsed, plus a reserved `correlation` escape-hatch map.
- **`intervals[]` with explicit `source`** (`log-delta` / `host-reported` / `http-reported` / `inferred` / `provider-reported`). No single canonical duration — the success fixture carries the real 34 / 54 / 294 ms triple.
- **`lanes[]` status metadata** (`reached` / `not-reached` / `failed-here` / `unknown`); `failureEvent` is required when a lane is `failed-here`.
- **Extension points**: `input`, `attributes`, `failures`, `metadata`.
- Parser-enforced referential invariants documented via `$comment` (JSON Schema can't enforce id refs).

## Validation
- `schemas/examples/success.example.json` (5 events, 3 intervals, all lanes reached) and `worker-fail.example.json` (empty intervals, client + application lanes `not-reached`) both validate.
- `tests/test_schema_v0_1.py` — 21 cases: accepts both examples, asserts the 3-ID/duration-triple/unreached-lane invariants, and rejects 11 structural violations. All pass.

## Review
Oracle-reviewed twice: 88 → applied all 5 blockers → **94/100, no blocking issues**.

Schema versioning is never-cut (PRD §11).