### PR TITLE
feat(models): frozen trace data models with schema parity (closes #2)

### DIFF
--- a/schemas/examples/success.example.json
+++ b/schemas/examples/success.example.json
@@ -75,7 +75,5 @@
       "startEvent": "e0", "endEvent": "e4", "durationMs": 294, "source": "http-reported", "confidence": "inferred",
       "raw": "\"duration\": \"294\""
     }
-  ],
-  "failures": [],
-  "metadata": {}
+  ]
 }

--- a/schemas/examples/worker-fail.example.json
+++ b/schemas/examples/worker-fail.example.json
@@ -45,6 +45,5 @@
   "intervals": [],
   "failures": [
     { "event": "e1", "kind": "worker-init", "message": "Worker failed to index functions (ModuleNotFoundError)." }
-  ],
-  "metadata": {}
+  ]
 }

--- a/src/funcviz/__init__.py
+++ b/src/funcviz/__init__.py
@@ -1,0 +1,3 @@
+"""funcviz — turn Azure Functions verbose runtime logs into an execution timeline."""
+
+__version__ = "0.1.0.dev0"

--- a/src/funcviz/models.py
+++ b/src/funcviz/models.py
@@ -1,0 +1,284 @@
+"""Frozen data models backing the v0.1 trace schema (schemas/trace-0.1.json).
+
+These are the parser's output types and the single serialization boundary:
+``Trace.to_dict()`` maps 1:1 onto the frozen schema's shape. A handful of
+cheap structural invariants (non-empty events, ``failed-here`` requires a
+``failureEvent``) are enforced in ``__post_init__``; richer semantic validation
+(id cross-references, ordering, duration provenance) is the parser's job, so a
+well-formed ``Trace`` serializes to schema-valid JSON but the models do not
+re-implement the full JSON Schema.
+``LogRecord`` is the parser's *input* type and is deliberately not narrowed to
+``str`` (PRD FR-2.1) so future adapters can carry structured fields.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+SCHEMA_VERSION = "0.1"
+
+
+class Lane(str, Enum):
+    CLIENT = "client"
+    HOST = "host"
+    PYTHON_WORKER = "python-worker"
+    APPLICATION = "application"
+
+
+class Confidence(str, Enum):
+    OBSERVED = "observed"
+    INFERRED = "inferred"
+    INSTRUMENTED = "instrumented"
+
+
+class Outcome(str, Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+
+
+class LaneState(str, Enum):
+    REACHED = "reached"
+    NOT_REACHED = "not-reached"
+    FAILED_HERE = "failed-here"
+    UNKNOWN = "unknown"
+
+
+class IntervalSource(str, Enum):
+    LOG_DELTA = "log-delta"
+    HOST_REPORTED = "host-reported"
+    HTTP_REPORTED = "http-reported"
+    INFERRED = "inferred"
+    PROVIDER_REPORTED = "provider-reported"
+
+
+@dataclass(frozen=True)
+class LogRecord:
+    message: str
+    timestamp: datetime | None = None
+    fields: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TraceInput:
+    source: str
+    adapter: str | None = None
+    adapter_version: str | None = None
+    extra: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {"source": self.source}
+        if self.adapter is not None:
+            out["adapter"] = self.adapter
+        if self.adapter_version is not None:
+            out["adapterVersion"] = self.adapter_version
+        out.update({k: v for k, v in self.extra.items() if k not in out})
+        return out
+
+
+@dataclass(frozen=True)
+class Runtime:
+    environment: str
+    language: str
+    trigger: str
+    core_tools_version: str | None = None
+    host_version: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {
+            "environment": self.environment,
+            "language": self.language,
+            "trigger": self.trigger,
+        }
+        if self.core_tools_version is not None:
+            out["coreToolsVersion"] = self.core_tools_version
+        if self.host_version is not None:
+            out["hostVersion"] = self.host_version
+        return out
+
+
+@dataclass(frozen=True)
+class Application:
+    function_name: str
+    source_file: str | None = None
+    source_text: str | None = None
+    definition_line_range: tuple[int, int] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {"functionName": self.function_name}
+        if self.source_file is not None:
+            out["sourceFile"] = self.source_file
+        if self.source_text is not None:
+            out["sourceText"] = self.source_text
+        if self.definition_line_range is not None:
+            out["definitionLineRange"] = list(self.definition_line_range)
+        return out
+
+
+@dataclass(frozen=True)
+class LaneStatus:
+    status: LaneState
+    confidence: Confidence
+    reason: str | None = None
+    failure_event: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status is LaneState.FAILED_HERE and self.failure_event is None:
+            raise ValueError("LaneStatus with status 'failed-here' requires a failure_event")
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {"status": self.status.value, "confidence": self.confidence.value}
+        if self.reason is not None:
+            out["reason"] = self.reason
+        if self.failure_event is not None:
+            out["failureEvent"] = self.failure_event
+        return out
+
+
+@dataclass(frozen=True)
+class Lanes:
+    client: LaneStatus
+    host: LaneStatus
+    python_worker: LaneStatus
+    application: LaneStatus
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "client": self.client.to_dict(),
+            "host": self.host.to_dict(),
+            "python-worker": self.python_worker.to_dict(),
+            "application": self.application.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class Event:
+    id: str
+    sequence: int
+    lane: Lane
+    event: str
+    confidence: Confidence
+    raw: str | None
+    timestamp: str | None = None
+    elapsed_ms: float | None = None
+    http_request_id: str | None = None
+    worker_request_id: str | None = None
+    invocation_id: str | None = None
+    correlation: Mapping[str, str] = field(default_factory=dict)
+    attributes: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {"id": self.id, "sequence": self.sequence}
+        if self.timestamp is not None:
+            out["timestamp"] = self.timestamp
+        if self.elapsed_ms is not None:
+            out["elapsedMs"] = self.elapsed_ms
+        out["lane"] = self.lane.value
+        out["event"] = self.event
+        if self.http_request_id is not None:
+            out["httpRequestId"] = self.http_request_id
+        if self.worker_request_id is not None:
+            out["workerRequestId"] = self.worker_request_id
+        if self.invocation_id is not None:
+            out["invocationId"] = self.invocation_id
+        if self.correlation:
+            out["correlation"] = dict(self.correlation)
+        out["confidence"] = self.confidence.value
+        if self.attributes:
+            out["attributes"] = dict(self.attributes)
+        out["raw"] = self.raw
+        return out
+
+
+@dataclass(frozen=True)
+class Interval:
+    id: str
+    label: str
+    lane: Lane
+    kind: str
+    start_event: str
+    end_event: str
+    duration_ms: float
+    source: IntervalSource
+    confidence: Confidence
+    attributes: Mapping[str, object] = field(default_factory=dict)
+    raw: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {
+            "id": self.id,
+            "label": self.label,
+            "lane": self.lane.value,
+            "kind": self.kind,
+            "startEvent": self.start_event,
+            "endEvent": self.end_event,
+            "durationMs": self.duration_ms,
+            "source": self.source.value,
+            "confidence": self.confidence.value,
+        }
+        if self.attributes:
+            out["attributes"] = dict(self.attributes)
+        if self.raw is not None:
+            out["raw"] = self.raw
+        return out
+
+
+@dataclass(frozen=True)
+class Failure:
+    event: str | None = None
+    kind: str | None = None
+    message: str | None = None
+    extra: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {}
+        if self.event is not None:
+            out["event"] = self.event
+        if self.kind is not None:
+            out["kind"] = self.kind
+        if self.message is not None:
+            out["message"] = self.message
+        out.update({k: v for k, v in self.extra.items() if k not in out})
+        return out
+
+
+@dataclass(frozen=True)
+class Trace:
+    trace_id: str
+    outcome: Outcome
+    input: TraceInput
+    runtime: Runtime
+    lanes: Lanes
+    events: Sequence[Event]
+    intervals: Sequence[Interval] = ()
+    application: Application | None = None
+    failures: Sequence[Failure] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.events:
+            raise ValueError("Trace requires at least one event")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"Trace.schema_version must be {SCHEMA_VERSION!r}")
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {
+            "schemaVersion": self.schema_version,
+            "traceId": self.trace_id,
+            "outcome": self.outcome.value,
+            "input": self.input.to_dict(),
+            "runtime": self.runtime.to_dict(),
+        }
+        if self.application is not None:
+            out["application"] = self.application.to_dict()
+        out["lanes"] = self.lanes.to_dict()
+        out["events"] = [e.to_dict() for e in self.events]
+        out["intervals"] = [i.to_dict() for i in self.intervals]
+        if self.failures:
+            out["failures"] = [f.to_dict() for f in self.failures]
+        if self.metadata:
+            out["metadata"] = dict(self.metadata)
+        return out

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,319 @@
+"""Round-trip tests for the data models (issue #2).
+
+Build the two shipped example traces as model objects, serialize them, and
+assert the output both validates against the frozen schema and equals the
+committed example JSON byte-for-value. This locks model<->schema parity.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from funcviz.models import (
+    Application,
+    Confidence,
+    Event,
+    Failure,
+    Interval,
+    IntervalSource,
+    Lane,
+    Lanes,
+    LaneState,
+    LaneStatus,
+    Outcome,
+    Runtime,
+    Trace,
+    TraceInput,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
+EXAMPLES = ROOT / "schemas" / "examples"
+
+SOURCE_TEXT = (
+    "import azure.functions as func\n\napp = func.FunctionApp()\n\n"
+    '@app.route(route="hello")\n'
+    "def hello(req: func.HttpRequest) -> func.HttpResponse:\n"
+    '    name = req.params.get("name") or "Azure"\n'
+    '    return func.HttpResponse(f"Hello, {name}!")\n'
+)
+
+
+def _local_input() -> TraceInput:
+    return TraceInput(source="core-tools-log", adapter="CoreToolsLogAdapter", adapter_version="0.1")
+
+
+def _local_runtime() -> Runtime:
+    return Runtime(
+        environment="local",
+        language="python",
+        trigger="http",
+        core_tools_version="TBD",
+        host_version="TBD",
+    )
+
+
+def build_success_trace() -> Trace:
+    inv = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
+    http = "2d0db691-8e70-4335-a8a9-e127715fa678"
+    worker = "e42785bf-7670-4de1-a81d-b05df7b2b32d"
+    return Trace(
+        trace_id="success-001",
+        outcome=Outcome.SUCCESS,
+        input=_local_input(),
+        runtime=_local_runtime(),
+        application=Application(
+            function_name="hello",
+            source_file="function_app.py",
+            source_text=SOURCE_TEXT,
+            definition_line_range=(5, 8),
+        ),
+        lanes=Lanes(
+            client=LaneStatus(
+                LaneState.REACHED,
+                Confidence.INFERRED,
+                reason="Derived from host HTTP request/response lines.",
+            ),
+            host=LaneStatus(LaneState.REACHED, Confidence.OBSERVED),
+            python_worker=LaneStatus(LaneState.REACHED, Confidence.OBSERVED),
+            application=LaneStatus(
+                LaneState.REACHED,
+                Confidence.INFERRED,
+                reason="User-code entry/exit is not separately logged.",
+            ),
+        ),
+        events=[
+            Event(
+                id="e0",
+                sequence=0,
+                timestamp="2026-09-05T00:45:16.955Z",
+                elapsed_ms=0,
+                lane=Lane.CLIENT,
+                event="HttpRequestReceived",
+                http_request_id=http,
+                confidence=Confidence.INFERRED,
+                raw='[2026-09-05T00:45:16.955Z] Executing HTTP request: { "requestId": '
+                '"2d0db691-8e70-4335-a8a9-e127715fa678", ... }',
+            ),
+            Event(
+                id="e1",
+                sequence=1,
+                timestamp="2026-09-05T00:45:17.206Z",
+                elapsed_ms=251,
+                lane=Lane.HOST,
+                event="InvocationStarted",
+                invocation_id=inv,
+                confidence=Confidence.OBSERVED,
+                raw="[2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='...', "
+                "Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)",
+            ),
+            Event(
+                id="e2",
+                sequence=2,
+                timestamp="2026-09-05T00:45:17.227Z",
+                elapsed_ms=272,
+                lane=Lane.PYTHON_WORKER,
+                event="WorkerReceivedInvocation",
+                worker_request_id=worker,
+                invocation_id=inv,
+                confidence=Confidence.OBSERVED,
+                raw="[2026-09-05T00:45:17.227Z] Received FunctionInvocationRequest, request ID: "
+                "e42785bf-..., invocation ID: 6a8f3658-...",
+            ),
+            Event(
+                id="e3",
+                sequence=3,
+                timestamp="2026-09-05T00:45:17.240Z",
+                elapsed_ms=285,
+                lane=Lane.HOST,
+                event="InvocationCompleted",
+                invocation_id=inv,
+                confidence=Confidence.OBSERVED,
+                raw="[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Succeeded, "
+                "Id=6a8f3658-..., Duration=54ms)",
+            ),
+            Event(
+                id="e4",
+                sequence=4,
+                timestamp="2026-09-05T00:45:17.249Z",
+                elapsed_ms=294,
+                lane=Lane.CLIENT,
+                event="HttpResponseReturned",
+                http_request_id=http,
+                confidence=Confidence.INFERRED,
+                raw='[2026-09-05T00:45:17.249Z] Executed HTTP request: { "requestId": '
+                '"2d0db691-...", "status": "200", "duration": "294" }',
+            ),
+        ],
+        intervals=[
+            Interval(
+                id="i1",
+                label="Invocation (host log delta)",
+                lane=Lane.HOST,
+                kind="invocation",
+                start_event="e1",
+                end_event="e3",
+                duration_ms=34,
+                source=IntervalSource.LOG_DELTA,
+                confidence=Confidence.OBSERVED,
+            ),
+            Interval(
+                id="i2",
+                label="Invocation (host-reported)",
+                lane=Lane.HOST,
+                kind="invocation",
+                start_event="e1",
+                end_event="e3",
+                duration_ms=54,
+                source=IntervalSource.HOST_REPORTED,
+                confidence=Confidence.OBSERVED,
+                raw="Duration=54ms",
+            ),
+            Interval(
+                id="i3",
+                label="HTTP request",
+                lane=Lane.CLIENT,
+                kind="http",
+                start_event="e0",
+                end_event="e4",
+                duration_ms=294,
+                source=IntervalSource.HTTP_REPORTED,
+                confidence=Confidence.INFERRED,
+                raw='"duration": "294"',
+            ),
+        ],
+    )
+
+
+def build_worker_fail_trace() -> Trace:
+    worker = "e42785bf-7670-4de1-a81d-b05df7b2b32d"
+    return Trace(
+        trace_id="worker-fail-001",
+        outcome=Outcome.FAILURE,
+        input=_local_input(),
+        runtime=_local_runtime(),
+        application=Application(function_name="hello", source_file="function_app.py"),
+        lanes=Lanes(
+            client=LaneStatus(
+                LaneState.NOT_REACHED,
+                Confidence.OBSERVED,
+                reason="No HTTP request was served; the worker failed to index functions "
+                "before any request.",
+            ),
+            host=LaneStatus(LaneState.FAILED_HERE, Confidence.OBSERVED, failure_event="e2"),
+            python_worker=LaneStatus(
+                LaneState.FAILED_HERE, Confidence.OBSERVED, failure_event="e1"
+            ),
+            application=LaneStatus(
+                LaneState.NOT_REACHED, Confidence.OBSERVED, reason="User code never executed."
+            ),
+        ),
+        events=[
+            Event(
+                id="e0",
+                sequence=0,
+                timestamp="2026-09-05T00:44:10.000Z",
+                elapsed_ms=0,
+                lane=Lane.PYTHON_WORKER,
+                event="WorkerStarting",
+                worker_request_id=worker,
+                confidence=Confidence.OBSERVED,
+                raw="[...] Starting Azure Functions Python Worker.",
+            ),
+            Event(
+                id="e1",
+                sequence=1,
+                timestamp="2026-09-05T00:44:11.000Z",
+                elapsed_ms=1000,
+                lane=Lane.PYTHON_WORKER,
+                event="WorkerIndexingError",
+                confidence=Confidence.OBSERVED,
+                attributes={"exception": "ModuleNotFoundError"},
+                raw="[...] Error in index_function_app. ModuleNotFoundError: "
+                "No module named 'nonexistent'",
+            ),
+            Event(
+                id="e2",
+                sequence=2,
+                timestamp="2026-09-05T00:44:11.100Z",
+                elapsed_ms=1100,
+                lane=Lane.HOST,
+                event="WorkerIndexingFailure",
+                confidence=Confidence.OBSERVED,
+                raw="[...] Worker failed to index functions. Result: Failure",
+            ),
+        ],
+        intervals=[],
+        failures=[
+            Failure(
+                event="e1",
+                kind="worker-init",
+                message="Worker failed to index functions (ModuleNotFoundError).",
+            )
+        ],
+    )
+
+
+def test_success_trace_matches_example_and_validates():
+    built = build_success_trace().to_dict()
+    example = json.loads((EXAMPLES / "success.example.json").read_text())
+    assert built == example
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(built))
+
+
+def test_worker_fail_trace_matches_example_and_validates():
+    built = build_worker_fail_trace().to_dict()
+    example = json.loads((EXAMPLES / "worker-fail.example.json").read_text())
+    assert built == example
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(built))
+
+
+def test_lane_enum_serializes_python_worker_with_hyphen():
+    assert Lane.PYTHON_WORKER.value == "python-worker"
+    assert build_success_trace().to_dict()["lanes"]["python-worker"]["status"] == "reached"
+
+
+def test_empty_optional_maps_are_omitted():
+    ev = build_success_trace().to_dict()["events"][0]
+    assert "correlation" not in ev
+    assert "attributes" not in ev
+
+
+def test_required_raw_is_emitted_even_when_none():
+    ev = Event(
+        id="x",
+        sequence=0,
+        lane=Lane.HOST,
+        event="Synth",
+        confidence=Confidence.INFERRED,
+        raw=None,
+    ).to_dict()
+    assert "raw" in ev and ev["raw"] is None
+
+
+def test_failed_here_lane_requires_failure_event():
+    with pytest.raises(ValueError):
+        LaneStatus(LaneState.FAILED_HERE, Confidence.OBSERVED)
+
+
+def test_trace_requires_at_least_one_event():
+    with pytest.raises(ValueError):
+        Trace(
+            trace_id="empty",
+            outcome=Outcome.SUCCESS,
+            input=_local_input(),
+            runtime=_local_runtime(),
+            lanes=build_success_trace().lanes,
+            events=[],
+        )
+
+
+def test_input_and_failure_carry_extension_fields():
+    inp = TraceInput(source="s", extra={"capture": "verbose"}).to_dict()
+    assert inp["capture"] == "verbose"
+    fail = Failure(event="e1", extra={"stackHash": "abc"}).to_dict()
+    assert fail["stackHash"] == "abc"


### PR DESCRIPTION
## Summary
- Add `src/funcviz` package (PEP 561 typed) with frozen dataclasses + `str`-Enums that back the frozen `schemas/trace-0.1.json`.
- Hand-written `to_dict()` is the single serialization boundary: empty optional maps omitted, `event.raw` always emitted (schema `string|null`), `python-worker` lane key hyphenated.
- Lightweight `__post_init__` invariants: non-empty events, `failed-here` lane requires `failureEvent`, pinned `schemaVersion`. Richer semantic validation remains the parser's job.
- `TraceInput`/`Failure` carry an `extra` map for schema `additionalProperties` (reserved keys not overridable).

## Tests
- Round-trip parity: both shipped examples built as models, asserted byte-for-value equal + schema-valid.
- Example JSON updated to drop empty optional maps for model parity.
- 29 tests pass, ruff clean, lsp clean.

## Review
Oracle review: 86 → **93/100**, no blockers.