### PR TITLE
feat(parser): pure success-path log parser (#3)

### DIFF
--- a/src/funcviz/parser/__init__.py
+++ b/src/funcviz/parser/__init__.py
@@ -1,0 +1,7 @@
+"""Pure Azure Functions log parser (PRD FR-2)."""
+
+from __future__ import annotations
+
+from .core import from_log_text, parse_trace
+
+__all__ = ["from_log_text", "parse_trace"]

--- a/src/funcviz/parser/core.py
+++ b/src/funcviz/parser/core.py
@@ -1,0 +1,110 @@
+"""Pure parser entry point: Iterable[LogRecord] -> Trace (PRD FR-2).
+
+``parse_trace`` performs no file or network I/O and knows nothing about the CLI.
+It folds multiline records, extracts the frozen event set, derives intervals and
+lane statuses, and reads only runtime metadata that is present in the log itself.
+Source-file text (application.sourceText) is intentionally left unset here: the
+parser never reads the filesystem, so a caller that wants source context loads it
+in a separate layer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ..models import (
+    Application,
+    Outcome,
+    Runtime,
+    Trace,
+    TraceInput,
+)
+from ..models import LogRecord as LogRecord
+from .derive import build_intervals, build_lanes, finalize_events
+from .events import extract_events
+from .records import fold_http_blocks, record_content
+from .records import from_log_text as _from_log_text
+from .regexes import (
+    find_core_tools_version,
+    find_function_path,
+    find_runtime_version,
+    find_worker_runtime,
+    match_invocation_started,
+)
+
+_ADAPTER = "CoreToolsLogAdapter"
+_ADAPTER_VERSION = "0.1"
+_SOURCE = "core-tools-log"
+
+
+def from_log_text(text: str) -> list[LogRecord]:
+    return _from_log_text(text)
+
+
+def parse_trace(
+    log_records: Iterable[LogRecord],
+    *,
+    trace_id: str,
+    outcome: Outcome = Outcome.SUCCESS,
+) -> Trace:
+    folded = fold_http_blocks(log_records)
+    raw_events = extract_events(folded)
+    finalized = finalize_events(raw_events)
+    intervals = build_intervals(finalized, raw_events)
+    lanes = build_lanes(finalized)
+
+    meta = _scan_metadata(folded)
+    completed = next((r for r in raw_events if r["event"] == "InvocationCompleted"), None)
+    resolved_outcome = _outcome_from(completed) if completed is not None else outcome
+
+    return Trace(
+        trace_id=trace_id,
+        outcome=resolved_outcome,
+        input=TraceInput(source=_SOURCE, adapter=_ADAPTER, adapter_version=_ADAPTER_VERSION),
+        runtime=Runtime(
+            environment="local",
+            language=meta.get("language", "python"),
+            trigger="http",
+            core_tools_version=meta.get("coreToolsVersion"),
+            host_version=meta.get("hostVersion"),
+        ),
+        lanes=lanes,
+        events=finalized,
+        intervals=intervals,
+        application=_application_from(meta),
+    )
+
+
+def _application_from(meta: dict[str, str]) -> Application | None:
+    name = meta.get("functionName")
+    if name is None:
+        return None
+    return Application(function_name=name, source_file=meta.get("sourceFile"))
+
+
+def _outcome_from(completed: dict[str, object]) -> Outcome:
+    return Outcome.SUCCESS if completed.get("result") == "Succeeded" else Outcome.FAILURE
+
+
+def _scan_metadata(folded: Iterable[LogRecord]) -> dict[str, str]:
+    meta: dict[str, str] = {}
+    for record in folded:
+        content = record_content(record)
+        _put(meta, "language", find_worker_runtime(content))
+        _put(meta, "coreToolsVersion", find_core_tools_version(content))
+        _put(meta, "hostVersion", find_runtime_version(content))
+        path = find_function_path(content)
+        if path is not None:
+            meta.setdefault("sourceFile", path.rsplit("/", 1)[-1])
+        started = match_invocation_started(content)
+        if started is not None:
+            meta.setdefault("functionName", started["name"])
+    return meta
+
+
+def _put(meta: dict[str, str], key: str, value: str | None) -> None:
+    if value is not None:
+        meta.setdefault(key, value)
+
+
+__all__ = ["from_log_text", "parse_trace"]

--- a/src/funcviz/parser/derive.py
+++ b/src/funcviz/parser/derive.py
@@ -1,0 +1,163 @@
+"""Derive finalized events, intervals, and lane statuses from raw extractions.
+
+This stage is regex-free and purely arithmetic/relational: it assigns event ids
+and sequences, computes ``elapsedMs`` relative to the first event, reconstructs
+the three provenance-tagged invocation/HTTP intervals, and infers lane
+reachability. Duration provenance (log-delta vs host-reported vs http-reported)
+is preserved deliberately per docs/event-coverage.md rather than collapsed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ..models import (
+    Confidence,
+    Event,
+    Interval,
+    IntervalSource,
+    Lane,
+    Lanes,
+    LaneState,
+    LaneStatus,
+)
+
+_CLIENT_REASON = "Derived from host HTTP request/response lines."
+_APPLICATION_REASON = "User-code entry/exit is not separately logged."
+
+
+def _to_dt(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def _elapsed_ms(ts: str, base: str) -> int:
+    return round((_to_dt(ts) - _to_dt(base)).total_seconds() * 1000)
+
+
+def finalize_events(raw_events: list[dict[str, object]]) -> list[Event]:
+    if not raw_events:
+        return []
+    base = str(raw_events[0]["timestamp"])
+    events: list[Event] = []
+    for n, raw in enumerate(raw_events):
+        ts = str(raw["timestamp"])
+        raw_text = raw["raw"]
+        events.append(
+            Event(
+                id=f"e{n}",
+                sequence=n,
+                lane=_as_lane(raw["lane"]),
+                event=str(raw["event"]),
+                confidence=_as_confidence(raw["confidence"]),
+                raw=raw_text if isinstance(raw_text, str) else None,
+                timestamp=ts,
+                elapsed_ms=_elapsed_ms(ts, base),
+                http_request_id=_opt_str(raw.get("httpRequestId")),
+                worker_request_id=_opt_str(raw.get("workerRequestId")),
+                invocation_id=_opt_str(raw.get("invocationId")),
+            )
+        )
+    return events
+
+
+def build_intervals(events: list[Event], raw_events: list[dict[str, object]]) -> list[Interval]:
+    by_name = {e.event: e for e in events}
+    raw_by_name = {str(r["event"]): r for r in raw_events}
+    intervals: list[Interval] = []
+
+    started = by_name.get("InvocationStarted")
+    completed = by_name.get("InvocationCompleted")
+    if started is not None and completed is not None and started.timestamp and completed.timestamp:
+        intervals.append(
+            Interval(
+                id="i1",
+                label="Invocation (host log delta)",
+                lane=Lane.HOST,
+                kind="invocation",
+                start_event=started.id,
+                end_event=completed.id,
+                duration_ms=_elapsed_ms(completed.timestamp, started.timestamp),
+                source=IntervalSource.LOG_DELTA,
+                confidence=Confidence.OBSERVED,
+            )
+        )
+        host_duration = _opt_str(raw_by_name["InvocationCompleted"].get("hostDuration"))
+        if host_duration is not None:
+            intervals.append(
+                Interval(
+                    id="i2",
+                    label="Invocation (host-reported)",
+                    lane=Lane.HOST,
+                    kind="invocation",
+                    start_event=started.id,
+                    end_event=completed.id,
+                    duration_ms=int(host_duration),
+                    source=IntervalSource.HOST_REPORTED,
+                    confidence=Confidence.OBSERVED,
+                    raw=f"Duration={host_duration}ms",
+                )
+            )
+
+    request = by_name.get("HttpRequestReceived")
+    response = by_name.get("HttpResponseReturned")
+    if request is not None and response is not None:
+        http_duration = _opt_str(raw_by_name["HttpResponseReturned"].get("httpDuration"))
+        if http_duration is not None:
+            intervals.append(
+                Interval(
+                    id="i3",
+                    label="HTTP request",
+                    lane=Lane.CLIENT,
+                    kind="http",
+                    start_event=request.id,
+                    end_event=response.id,
+                    duration_ms=int(http_duration),
+                    source=IntervalSource.HTTP_REPORTED,
+                    confidence=Confidence.INFERRED,
+                    raw=f'"duration": "{http_duration}"',
+                )
+            )
+    return intervals
+
+
+def build_lanes(events: list[Event]) -> Lanes:
+    names = {e.event for e in events}
+    completed = next((e for e in events if e.event == "InvocationCompleted"), None)
+    application_reached = completed is not None
+
+    client_reached = bool(names & {"HttpRequestReceived", "HttpResponseReturned"})
+    host_reached = bool(names & {"InvocationStarted", "InvocationCompleted"})
+    worker_reached = "WorkerReceivedInvocation" in names
+
+    return Lanes(
+        client=LaneStatus(
+            LaneState.REACHED if client_reached else LaneState.NOT_REACHED,
+            Confidence.INFERRED,
+            reason=_CLIENT_REASON,
+        ),
+        host=LaneStatus(
+            LaneState.REACHED if host_reached else LaneState.NOT_REACHED,
+            Confidence.OBSERVED,
+        ),
+        python_worker=LaneStatus(
+            LaneState.REACHED if worker_reached else LaneState.NOT_REACHED,
+            Confidence.OBSERVED,
+        ),
+        application=LaneStatus(
+            LaneState.REACHED if application_reached else LaneState.NOT_REACHED,
+            Confidence.INFERRED,
+            reason=_APPLICATION_REASON,
+        ),
+    )
+
+
+def _as_lane(value: object) -> Lane:
+    return value if isinstance(value, Lane) else Lane(str(value))
+
+
+def _as_confidence(value: object) -> Confidence:
+    return value if isinstance(value, Confidence) else Confidence(str(value))
+
+
+def _opt_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/src/funcviz/parser/events.py
+++ b/src/funcviz/parser/events.py
@@ -1,0 +1,107 @@
+"""Extract the five frozen events from folded records, in log order.
+
+The event vocabulary is exactly what survived the Phase 0 coverage matrix
+(docs/event-coverage.md): HttpRequestReceived, InvocationStarted,
+WorkerReceivedInvocation, InvocationCompleted, HttpResponseReturned. This stage
+owns no regexes; it delegates every log-shape decision to :mod:`.regexes` and
+emits order-preserving intermediate dicts that :mod:`.derive` finalizes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ..models import Confidence, Lane, LogRecord
+from .records import record_content, record_timestamp
+from .regexes import (
+    find_http_duration,
+    find_http_request_id,
+    is_http_request_start,
+    is_http_response_start,
+    match_invocation_completed,
+    match_invocation_started,
+    match_worker_invocation,
+)
+
+
+def extract_events(folded: Iterable[LogRecord]) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for record in folded:
+        content = record_content(record)
+        ts = record_timestamp(record)
+
+        if is_http_request_start(content):
+            http_id = find_http_request_id(content)
+            events.append(
+                {
+                    "event": "HttpRequestReceived",
+                    "lane": Lane.CLIENT,
+                    "confidence": Confidence.INFERRED,
+                    "timestamp": ts,
+                    "raw": record.message,
+                    "httpRequestId": http_id,
+                }
+            )
+            continue
+
+        if is_http_response_start(content):
+            http_id = find_http_request_id(content)
+            events.append(
+                {
+                    "event": "HttpResponseReturned",
+                    "lane": Lane.CLIENT,
+                    "confidence": Confidence.INFERRED,
+                    "timestamp": ts,
+                    "raw": record.message,
+                    "httpRequestId": http_id,
+                    "httpDuration": find_http_duration(content),
+                }
+            )
+            continue
+
+        started = match_invocation_started(content)
+        if started is not None:
+            events.append(
+                {
+                    "event": "InvocationStarted",
+                    "lane": Lane.HOST,
+                    "confidence": Confidence.OBSERVED,
+                    "timestamp": ts,
+                    "raw": record.message,
+                    "invocationId": started["invocation"],
+                }
+            )
+            continue
+
+        worker = match_worker_invocation(content)
+        if worker is not None:
+            events.append(
+                {
+                    "event": "WorkerReceivedInvocation",
+                    "lane": Lane.PYTHON_WORKER,
+                    "confidence": Confidence.OBSERVED,
+                    "timestamp": ts,
+                    "raw": record.message,
+                    "workerRequestId": worker["worker"],
+                    "invocationId": worker["invocation"],
+                }
+            )
+            continue
+
+        completed = match_invocation_completed(content)
+        if completed is not None:
+            events.append(
+                {
+                    "event": "InvocationCompleted",
+                    "lane": Lane.HOST,
+                    "confidence": Confidence.OBSERVED,
+                    "timestamp": ts,
+                    "raw": record.message,
+                    "invocationId": completed["invocation"],
+                    "result": completed["result"],
+                    "hostDuration": completed["duration"],
+                }
+            )
+            continue
+
+    return events

--- a/src/funcviz/parser/records.py
+++ b/src/funcviz/parser/records.py
@@ -1,0 +1,96 @@
+"""Physical log lines -> logical records, folding multiline HTTP JSON blocks.
+
+The Core Tools HTTP request/response lines emit a pretty-printed JSON body where
+every physical line carries its own ``[timestamp]`` prefix. This stage folds
+such a block back into a single :class:`~funcviz.models.LogRecord` whose message
+is the joined original text, so no downstream extractor needs multiline
+awareness. Only known HTTP request/response blocks are folded; unrelated JSON
+config dumps in startup noise are left as-is.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+
+from ..models import LogRecord
+from .regexes import is_http_request_start, is_http_response_start, split_timestamp
+
+
+def from_log_text(text: str) -> list[LogRecord]:
+    records: list[LogRecord] = []
+    for line in text.splitlines():
+        ts, content = split_timestamp(line)
+        records.append(
+            LogRecord(message=line, timestamp=None, fields={"content": content, "ts": ts or ""})
+        )
+    return records
+
+
+def record_content(record: LogRecord) -> str:
+    """The log-message body, preferring a pre-split ``fields['content']``.
+
+    A raw ``LogRecord(message=line)`` from an adapter that did not pre-split is
+    supported: the ``[timestamp]`` prefix is stripped from ``message`` on demand
+    so ``parse_trace`` honors its ``Iterable[LogRecord]`` contract regardless of
+    whether ``from_log_text`` was used.
+    """
+    value = record.fields.get("content")
+    if isinstance(value, str):
+        return value
+    _, content = split_timestamp(record.message)
+    return content
+
+
+def record_timestamp(record: LogRecord) -> str:
+    """The record's ISO timestamp, resolved in fields-first order (PRD FR-2.1).
+
+    Structured ``fields['ts']`` wins; a structured ``LogRecord.timestamp`` is
+    next; only then is the ``[timestamp]`` prefix parsed out of ``message``. This
+    lets adapters carry timestamps as data while a bare ``message``-only record
+    still yields a usable timestamp for interval derivation.
+    """
+    value = record.fields.get("ts")
+    if isinstance(value, str) and value:
+        return value
+    if record.timestamp is not None:
+        return _format_timestamp(record.timestamp)
+    ts, _ = split_timestamp(record.message)
+    return ts or ""
+
+
+def _format_timestamp(moment: datetime) -> str:
+    return moment.isoformat()
+
+
+def fold_http_blocks(records: Iterable[LogRecord]) -> list[LogRecord]:
+    items = list(records)
+    folded: list[LogRecord] = []
+    i = 0
+    while i < len(items):
+        record = items[i]
+        content = record_content(record)
+        if is_http_request_start(content) or is_http_response_start(content):
+            depth = content.count("{") - content.count("}")
+            block = [record]
+            j = i + 1
+            while depth > 0 and j < len(items):
+                nxt = items[j]
+                nxt_content = record_content(nxt)
+                depth += nxt_content.count("{") - nxt_content.count("}")
+                block.append(nxt)
+                j += 1
+            joined_message = "\n".join(b.message for b in block)
+            joined_content = "\n".join(record_content(b) for b in block)
+            folded.append(
+                LogRecord(
+                    message=joined_message,
+                    timestamp=None,
+                    fields={"content": joined_content, "ts": record_timestamp(record)},
+                )
+            )
+            i = j
+        else:
+            folded.append(record)
+            i += 1
+    return folded

--- a/src/funcviz/parser/regexes.py
+++ b/src/funcviz/parser/regexes.py
@@ -1,0 +1,99 @@
+"""The only module in the parser that touches ``re`` (PRD R1 mitigation).
+
+Every log-shape assumption lives here as a named pattern with a typed accessor.
+Downstream stages consume the returned match dictionaries and never see raw
+regex groups, so a Core Tools log-format change is a one-file edit.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TIMESTAMP = re.compile(r"^\[(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\]\s?(?P<rest>.*)$")
+_WORKER_RUNTIME = re.compile(r"Resolving worker runtime to '(?P<lang>[^']+)'")
+_CORE_TOOLS_VERSION = re.compile(r"Core Tools Version:\s*(?P<version>\S+)")
+_RUNTIME_VERSION = re.compile(r"Function Runtime Version:\s*(?P<version>\S+)")
+_FUNCTION_PATH = re.compile(r"function_path:\s*(?P<path>\S+)")
+
+_INVOCATION_STARTED = re.compile(
+    r"Executing 'Functions\.(?P<name>[^']+)'.*\bId=(?P<invocation>[0-9a-fA-F-]{36})"
+)
+_INVOCATION_COMPLETED = re.compile(
+    r"Executed 'Functions\.(?P<name>[^']+)' \((?P<result>Succeeded|Failed), "
+    r"Id=(?P<invocation>[0-9a-fA-F-]{36}), Duration=(?P<duration>\d+)ms\)"
+)
+_WORKER_INVOCATION = re.compile(
+    r"Received FunctionInvocationRequest, request ID: (?P<worker>[0-9a-fA-F-]{36}),"
+    r".*invocation ID: (?P<invocation>[0-9a-fA-F-]{36})"
+)
+_HTTP_REQUEST_ID = re.compile(r'"requestId":\s*"(?P<http>[0-9a-fA-F-]{36})"')
+_HTTP_STATUS = re.compile(r'"status":\s*"(?P<status>\d+)"')
+_HTTP_DURATION = re.compile(r'"duration":\s*"(?P<duration>\d+)"')
+
+_HTTP_REQUEST_START = "Executing HTTP request:"
+_HTTP_RESPONSE_START = "Executed HTTP request:"
+
+
+def split_timestamp(line: str) -> tuple[str | None, str]:
+    m = _TIMESTAMP.match(line)
+    if m is None:
+        return None, line
+    return m.group("ts"), m.group("rest")
+
+
+def is_http_request_start(content: str) -> bool:
+    return content.startswith(_HTTP_REQUEST_START)
+
+
+def is_http_response_start(content: str) -> bool:
+    return content.startswith(_HTTP_RESPONSE_START)
+
+
+def match_invocation_started(content: str) -> dict[str, str] | None:
+    m = _INVOCATION_STARTED.search(content)
+    return m.groupdict() if m else None
+
+
+def match_invocation_completed(content: str) -> dict[str, str] | None:
+    m = _INVOCATION_COMPLETED.search(content)
+    return m.groupdict() if m else None
+
+
+def match_worker_invocation(content: str) -> dict[str, str] | None:
+    m = _WORKER_INVOCATION.search(content)
+    return m.groupdict() if m else None
+
+
+def find_http_request_id(content: str) -> str | None:
+    m = _HTTP_REQUEST_ID.search(content)
+    return m.group("http") if m else None
+
+
+def find_http_status(content: str) -> str | None:
+    m = _HTTP_STATUS.search(content)
+    return m.group("status") if m else None
+
+
+def find_http_duration(content: str) -> str | None:
+    m = _HTTP_DURATION.search(content)
+    return m.group("duration") if m else None
+
+
+def find_worker_runtime(content: str) -> str | None:
+    m = _WORKER_RUNTIME.search(content)
+    return m.group("lang") if m else None
+
+
+def find_core_tools_version(content: str) -> str | None:
+    m = _CORE_TOOLS_VERSION.search(content)
+    return m.group("version") if m else None
+
+
+def find_runtime_version(content: str) -> str | None:
+    m = _RUNTIME_VERSION.search(content)
+    return m.group("version") if m else None
+
+
+def find_function_path(content: str) -> str | None:
+    m = _FUNCTION_PATH.search(content)
+    return m.group("path") if m else None

--- a/tests/test_parser_success.py
+++ b/tests/test_parser_success.py
@@ -1,0 +1,97 @@
+"""Golden-output smoke test for the pure parser (issue #3).
+
+Parses the committed success.log fixture and asserts the structural contract
+that issue #4 will expand: schema validity, frozen event order, monotonic
+elapsed times, and the three provenance-tagged intervals. Byte-for-byte golden
+comparison against traces/success.json guards against silent regressions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from funcviz.models import LogRecord
+from funcviz.parser import from_log_text, parse_trace
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
+
+FROZEN_EVENTS = [
+    "HttpRequestReceived",
+    "InvocationStarted",
+    "WorkerReceivedInvocation",
+    "InvocationCompleted",
+    "HttpResponseReturned",
+]
+
+
+def _parsed() -> dict[str, object]:
+    text = (ROOT / "samples" / "success.log").read_text()
+    return parse_trace(from_log_text(text), trace_id="success-001").to_dict()
+
+
+def test_success_log_validates_against_schema():
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(_parsed()))
+
+
+def test_event_order_matches_log_order():
+    doc = _parsed()
+    assert [e["event"] for e in doc["events"]] == FROZEN_EVENTS
+    assert [e["elapsedMs"] for e in doc["events"]] == [0, 251, 272, 285, 294]
+
+
+def test_intervals_preserve_duration_provenance():
+    intervals = _parsed()["intervals"]
+    assert [(i["id"], i["source"], i["durationMs"]) for i in intervals] == [
+        ("i1", "log-delta", 34),
+        ("i2", "host-reported", 54),
+        ("i3", "http-reported", 294),
+    ]
+
+
+def test_three_id_correlation_is_separated():
+    worker_event = _parsed()["events"][2]
+    assert worker_event["workerRequestId"] == "e42785bf-7670-4de1-a81d-b05df7b2b32d"
+    assert worker_event["invocationId"] == "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
+
+
+def test_parser_output_matches_committed_golden():
+    golden = json.loads((ROOT / "traces" / "success.json").read_text())
+    assert _parsed() == golden
+
+
+def test_multiline_http_block_is_folded_into_one_event():
+    events = _parsed()["events"]
+    http_events = [e for e in events if e["event"].startswith("Http")]
+    assert len(http_events) == 2
+    assert all("\n" in e["raw"] for e in http_events)
+
+
+def test_bare_message_records_parse_without_from_log_text():
+    text = (ROOT / "samples" / "success.log").read_text()
+    bare = [LogRecord(message=line) for line in text.splitlines()]
+    assert parse_trace(bare, trace_id="success-001").to_dict() == _parsed()
+
+
+def test_structured_timestamp_is_honored_over_message_prefix():
+    started = (
+        "[2024-01-01T00:00:00.100Z] Executing 'Functions.hello' "
+        "(Reason='...', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)"
+    )
+    completed = (
+        "[9999-01-01T00:00:00.000Z] Executed 'Functions.hello' "
+        "(Succeeded, Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b, Duration=54ms)"
+    )
+    records = [
+        LogRecord(message=started),
+        LogRecord(
+            message=completed,
+            timestamp=datetime(2024, 1, 1, 0, 0, 0, 400000, tzinfo=timezone.utc),
+        ),
+    ]
+    events = parse_trace(records, trace_id="ts-001").to_dict()["events"]
+    assert [e["elapsedMs"] for e in events] == [0, 300]

--- a/traces/success.json
+++ b/traces/success.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": "0.1",
+  "traceId": "success-001",
+  "outcome": "success",
+  "input": {
+    "source": "core-tools-log",
+    "adapter": "CoreToolsLogAdapter",
+    "adapterVersion": "0.1"
+  },
+  "runtime": {
+    "environment": "local",
+    "language": "python",
+    "trigger": "http",
+    "coreToolsVersion": "4.6.0+ab90faafcab539d63cd3d0ce5faf1bca4395fccc",
+    "hostVersion": "4.1045.200.25556"
+  },
+  "application": {
+    "functionName": "hello",
+    "sourceFile": "function_app.py"
+  },
+  "lanes": {
+    "client": {
+      "status": "reached",
+      "confidence": "inferred",
+      "reason": "Derived from host HTTP request/response lines."
+    },
+    "host": {
+      "status": "reached",
+      "confidence": "observed"
+    },
+    "python-worker": {
+      "status": "reached",
+      "confidence": "observed"
+    },
+    "application": {
+      "status": "reached",
+      "confidence": "inferred",
+      "reason": "User-code entry/exit is not separately logged."
+    }
+  },
+  "events": [
+    {
+      "id": "e0",
+      "sequence": 0,
+      "timestamp": "2026-09-05T00:45:16.955Z",
+      "elapsedMs": 0,
+      "lane": "client",
+      "event": "HttpRequestReceived",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:16.955Z] Executing HTTP request: {\n[2026-09-05T00:45:16.955Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:16.955Z]   \"method\": \"GET\",\n[2026-09-05T00:45:16.955Z]   \"userAgent\": \"curl/8.7.1\",\n[2026-09-05T00:45:16.955Z]   \"uri\": \"/api/hello\"\n[2026-09-05T00:45:16.955Z] }"
+    },
+    {
+      "id": "e1",
+      "sequence": 1,
+      "timestamp": "2026-09-05T00:45:17.206Z",
+      "elapsedMs": 251,
+      "lane": "host",
+      "event": "InvocationStarted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='This function was programmatically called via the host APIs.', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)"
+    },
+    {
+      "id": "e2",
+      "sequence": 2,
+      "timestamp": "2026-09-05T00:45:17.227Z",
+      "elapsedMs": 272,
+      "lane": "python-worker",
+      "event": "WorkerReceivedInvocation",
+      "workerRequestId": "e42785bf-7670-4de1-a81d-b05df7b2b32d",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.227Z] Received FunctionInvocationRequest, request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, function ID: 4d71d03f-f19b-5d9e-8523-9628ba18063c, function name: hello, invocation ID: 6a8f3658-2b31-4554-aa86-1ee32a9e679b, function type: sync, timestamp (UTC): 2026-09-05 00:45:17.226806, sync threadpool max workers: 1000"
+    },
+    {
+      "id": "e3",
+      "sequence": 3,
+      "timestamp": "2026-09-05T00:45:17.240Z",
+      "elapsedMs": 285,
+      "lane": "host",
+      "event": "InvocationCompleted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Succeeded, Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b, Duration=54ms)"
+    },
+    {
+      "id": "e4",
+      "sequence": 4,
+      "timestamp": "2026-09-05T00:45:17.249Z",
+      "elapsedMs": 294,
+      "lane": "client",
+      "event": "HttpResponseReturned",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:17.249Z] Executed HTTP request: {\n[2026-09-05T00:45:17.249Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:17.249Z]   \"identities\": \"(WebJobsAuthLevel:Admin)\",\n[2026-09-05T00:45:17.249Z]   \"status\": \"200\",\n[2026-09-05T00:45:17.249Z]   \"duration\": \"294\"\n[2026-09-05T00:45:17.249Z] }"
+    }
+  ],
+  "intervals": [
+    {
+      "id": "i1",
+      "label": "Invocation (host log delta)",
+      "lane": "host",
+      "kind": "invocation",
+      "startEvent": "e1",
+      "endEvent": "e3",
+      "durationMs": 34,
+      "source": "log-delta",
+      "confidence": "observed"
+    },
+    {
+      "id": "i2",
+      "label": "Invocation (host-reported)",
+      "lane": "host",
+      "kind": "invocation",
+      "startEvent": "e1",
+      "endEvent": "e3",
+      "durationMs": 54,
+      "source": "host-reported",
+      "confidence": "observed",
+      "raw": "Duration=54ms"
+    },
+    {
+      "id": "i3",
+      "label": "HTTP request",
+      "lane": "client",
+      "kind": "http",
+      "startEvent": "e0",
+      "endEvent": "e4",
+      "durationMs": 294,
+      "source": "http-reported",
+      "confidence": "inferred",
+      "raw": "\"duration\": \"294\""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds the pure parser layer (`src/funcviz/parser/`) that turns verbose Azure Functions Core Tools logs into a schema-valid `Trace` — no file or CLI knowledge inside the parser (PRD FR-2).
- All log regexes isolated in `regexes.py` (R1 mitigation); every other stage is regex-free.
- Fields-first timestamp/content resolution (`fields` → `LogRecord.timestamp` → `message` prefix) so `parse_trace` honors its `Iterable[LogRecord]` contract even for bare `message`-only records.
- Preserves the three duration provenances (log-delta / host-reported / http-reported) and separates the httpRequestId / workerRequestId / invocationId correlation.

## Pipeline
`records` (fold multiline HTTP JSON blocks) → `events` (extract 5 frozen events) → `derive` (ids, elapsedMs, intervals, lanes) → `core.parse_trace`.

## Verification
- 37 tests pass, ruff clean, basedpyright clean (0 errors).
- Generated `traces/success.json` validates against the frozen `schemas/trace-0.1.json`.
- Oracle architecture review: 94/100, no blockers.

Closes #3.