### PR TITLE
test(parser): success contracts + failure-log drift guards (#4)

### DIFF
--- a/tests/test_parser_contracts.py
+++ b/tests/test_parser_contracts.py
@@ -1,0 +1,135 @@
+"""Semantic contracts for the success-path parser (issue #4, PRD R1).
+
+These lock down *why* the golden trace looks the way it does — lane
+reachability and confidence, per-event confidence classification, three-way ID
+correlation, and ordering invariants — so a Core Tools log-format drift fails
+with a targeted assertion instead of an opaque golden diff.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from funcviz.parser import from_log_text, parse_trace
+
+ROOT = Path(__file__).resolve().parent.parent
+HTTP_REQUEST_ID = "2d0db691-8e70-4335-a8a9-e127715fa678"
+WORKER_REQUEST_ID = "e42785bf-7670-4de1-a81d-b05df7b2b32d"
+INVOCATION_ID = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
+
+
+def _trace() -> dict[str, object]:
+    text = (ROOT / "samples" / "success.log").read_text()
+    return parse_trace(from_log_text(text), trace_id="success-001").to_dict()
+
+
+def _events() -> list[dict[str, object]]:
+    events = _trace()["events"]
+    assert isinstance(events, list)
+    return events
+
+
+def _lanes() -> dict[str, object]:
+    lanes = _trace()["lanes"]
+    assert isinstance(lanes, dict)
+    return lanes
+
+
+def test_all_four_lanes_reached_with_expected_confidence():
+    lanes = _lanes()
+    assert set(lanes) == {"client", "host", "python-worker", "application"}
+    expected = {
+        "client": "inferred",
+        "host": "observed",
+        "python-worker": "observed",
+        "application": "inferred",
+    }
+    for name, confidence in expected.items():
+        status = lanes[name]
+        assert isinstance(status, dict)
+        assert status["status"] == "reached"
+        assert status["confidence"] == confidence
+
+
+def test_inferred_lanes_carry_a_reason_and_no_lane_reports_failure():
+    lanes = _lanes()
+    for name in ("client", "application"):
+        status = lanes[name]
+        assert isinstance(status, dict)
+        assert isinstance(status.get("reason"), str) and status["reason"]
+    for status in lanes.values():
+        assert isinstance(status, dict)
+        assert "failureEvent" not in status
+
+
+def test_event_confidence_is_classified_by_deliberate_rule():
+    observed = {"InvocationStarted", "WorkerReceivedInvocation", "InvocationCompleted"}
+    inferred = {"HttpRequestReceived", "HttpResponseReturned"}
+    for event in _events():
+        name = event["event"]
+        if name in observed:
+            assert event["confidence"] == "observed", name
+        elif name in inferred:
+            assert event["confidence"] == "inferred", name
+        else:
+            raise AssertionError(f"unexpected event {name!r}")
+
+
+def test_no_success_event_claims_instrumented_confidence():
+    assert all(event["confidence"] != "instrumented" for event in _events())
+
+
+def test_three_ids_stay_distinct_and_attach_to_the_right_events():
+    by_name = {event["event"]: event for event in _events()}
+
+    assert len({HTTP_REQUEST_ID, WORKER_REQUEST_ID, INVOCATION_ID}) == 3
+
+    for name in ("HttpRequestReceived", "HttpResponseReturned"):
+        event = by_name[name]
+        assert event["httpRequestId"] == HTTP_REQUEST_ID
+        assert "invocationId" not in event
+        assert "workerRequestId" not in event
+
+    worker = by_name["WorkerReceivedInvocation"]
+    assert worker["workerRequestId"] == WORKER_REQUEST_ID
+    assert worker["invocationId"] == INVOCATION_ID
+
+    for name in ("InvocationStarted", "InvocationCompleted"):
+        event = by_name[name]
+        assert event["invocationId"] == INVOCATION_ID
+        assert "httpRequestId" not in event
+        assert "workerRequestId" not in event
+
+
+def test_lifecycle_ordering_invariants_hold():
+    events = _events()
+
+    def seq(name: str) -> int:
+        for event in events:
+            if event["event"] == name:
+                value = event["sequence"]
+                assert isinstance(value, int)
+                return value
+        raise AssertionError(f"missing event {name!r}")
+
+    assert seq("HttpRequestReceived") < seq("InvocationStarted")
+    assert seq("InvocationStarted") < seq("WorkerReceivedInvocation")
+    assert seq("WorkerReceivedInvocation") < seq("InvocationCompleted")
+    assert seq("InvocationCompleted") < seq("HttpResponseReturned")
+
+
+def test_elapsed_is_non_negative_and_monotonic():
+    elapsed: list[int] = []
+    for event in _events():
+        value = event["elapsedMs"]
+        assert isinstance(value, int)
+        elapsed.append(value)
+    assert elapsed[0] == 0
+    assert all(value >= 0 for value in elapsed)
+    assert elapsed == sorted(elapsed)
+
+
+def test_golden_is_the_end_to_end_contract():
+    golden = json.loads((ROOT / "traces" / "success.json").read_text())
+    assert _trace() == golden

--- a/tests/test_parser_regex_isolation.py
+++ b/tests/test_parser_regex_isolation.py
@@ -1,0 +1,31 @@
+"""Structural guard: only the regexes module may import ``re`` (PRD R1).
+
+Centralizing every log-shape assumption in one file is the project's core
+format-drift mitigation; this test fails loudly if regex logic leaks into any
+other parser stage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PARSER_DIR = Path(__file__).resolve().parent.parent / "src" / "funcviz" / "parser"
+
+
+def _imports_re(source: str) -> bool:
+    for raw in source.splitlines():
+        line = raw.strip()
+        if line in ("import re", "import re as re"):
+            return True
+        if line.startswith(("import re ", "import re,", "from re import", "from re.")):
+            return True
+    return False
+
+
+def test_only_regexes_module_imports_re():
+    offenders = [
+        path.name
+        for path in sorted(PARSER_DIR.glob("*.py"))
+        if path.name != "regexes.py" and _imports_re(path.read_text())
+    ]
+    assert offenders == []

--- a/tests/test_parser_worker_fail_regexes.py
+++ b/tests/test_parser_worker_fail_regexes.py
@@ -1,0 +1,77 @@
+"""Regex-layer drift guard for the failure fixture (issue #4, scope-limited).
+
+Full failure-trace derivation is issue #9. Here we only characterize that the
+shared startup/metadata regexes still recognize ``worker-fail.log`` and that the
+success-path event regexes correctly find nothing in it, so a Core Tools format
+bump surfaces as a named regex assertion rather than a surprise in #9.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from funcviz.parser import from_log_text, parse_trace
+from funcviz.parser.regexes import (
+    find_core_tools_version,
+    find_function_path,
+    find_runtime_version,
+    find_worker_runtime,
+    match_invocation_completed,
+    match_invocation_started,
+    match_worker_invocation,
+    split_timestamp,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _content_lines() -> list[str]:
+    text = (ROOT / "samples" / "worker-fail.log").read_text()
+    return [split_timestamp(line)[1] for line in text.splitlines()]
+
+
+def _find(lines: list[str], finder: Callable[[str], str | None]) -> str | None:
+    for line in lines:
+        value = finder(line)
+        if value is not None:
+            return value
+    return None
+
+
+def test_shared_startup_metadata_still_matches():
+    lines = _content_lines()
+    assert _find(lines, find_worker_runtime) == "python"
+    core_tools = _find(lines, find_core_tools_version)
+    assert core_tools is not None and core_tools.startswith("4.6.0")
+    assert _find(lines, find_runtime_version) == "4.1045.200.25556"
+    path = _find(lines, find_function_path)
+    assert path is not None and path.endswith("function_app.py")
+
+
+def test_success_event_regexes_find_no_invocation_or_worker_events():
+    lines = _content_lines()
+    assert all(match_invocation_started(line) is None for line in lines)
+    assert all(match_invocation_completed(line) is None for line in lines)
+    assert all(match_worker_invocation(line) is None for line in lines)
+
+
+def test_failure_shape_markers_are_still_present():
+    text = (ROOT / "samples" / "worker-fail.log").read_text()
+    markers = [
+        "Error in index_function_app",
+        "No module named 'this_module_does_not_exist'",
+        "Worker failed to index functions",
+        "Result: Failure",
+        "0 functions found",
+    ]
+    for marker in markers:
+        assert marker in text, marker
+
+
+def test_success_parser_cannot_yet_build_a_trace_from_failure_log():
+    text = (ROOT / "samples" / "worker-fail.log").read_text()
+    with pytest.raises(ValueError):
+        parse_trace(from_log_text(text), trace_id="worker-fail-001")


### PR DESCRIPTION
## Summary
- Adds semantic **success-path contracts** (`tests/test_parser_contracts.py`) that explain *why* the golden trace looks as it does: all four lane statuses/confidence/reasons, per-event confidence classification, three-way httpRequestId/workerRequestId/invocationId separation, lifecycle ordering, and elapsed monotonicity — so Core Tools format drift fails with a targeted assertion, not an opaque golden diff (PRD R1).
- Adds a **scope-limited `worker-fail.log` drift guard** (`tests/test_parser_worker_fail_regexes.py`): shared startup/metadata regexes still match, success-path event regexes correctly find nothing, failure-shape markers are still present, and `parse_trace` raises on the failure log. Full failure-trace derivation stays in #9.
- Adds a **regex-isolation structural guard** (`tests/test_parser_regex_isolation.py`): only `regexes.py` imports `re`.

## Verification
- 50 tests pass (was 37), ruff clean. No production code changed.
- Oracle review: 91/100, no blockers (plus the two recommended polish items applied).

Closes #4.