### PR TITLE
feat(cli): funcviz parse / view / record (#8)

### DIFF
--- a/src/funcviz/cli.py
+++ b/src/funcviz/cli.py
@@ -1,0 +1,300 @@
+"""funcviz command-line interface (PRD FR-1, FR-3).
+
+Three subcommands, all pure log *readers* — funcviz never starts, wraps, or
+supervises the Azure Functions host:
+
+* ``parse``  — turn a log file (or stdin) into schema-0.1 trace JSON.
+* ``view``   — open a trace in the self-contained static viewer.
+* ``record`` — read stdin until EOF/Ctrl-C and write the resulting trace.
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import hashlib
+import http.server
+import json
+import re
+import sys
+import tempfile
+from collections.abc import Callable
+from importlib import resources
+from pathlib import Path
+from typing import TextIO
+from urllib.request import pathname2url
+
+from funcviz.parser import from_log_text, parse_trace
+
+Opener = Callable[[str], object]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="funcviz",
+        description="Azure Functions runtime log visualizer.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parse_cmd = subparsers.add_parser(
+        "parse",
+        help="Parse Azure Functions runtime logs into funcviz trace JSON.",
+    )
+    parse_cmd.add_argument("input", help="Log file path, or '-' to read from stdin.")
+    parse_cmd.add_argument(
+        "-o",
+        "--output",
+        default="-",
+        help="Output trace JSON path, or '-' for stdout (default: stdout).",
+    )
+    parse_cmd.add_argument("--trace-id", help="Override the generated traceId.")
+    parse_cmd.set_defaults(handler=cmd_parse)
+
+    view_cmd = subparsers.add_parser(
+        "view",
+        help="Open a trace JSON file in the static funcviz viewer.",
+    )
+    view_cmd.add_argument("trace", help="Trace JSON file to view.")
+    view_cmd.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="Local port for the viewer server (default: ephemeral).",
+    )
+    view_cmd.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Start the server but do not open a browser; print the URL.",
+    )
+    view_cmd.add_argument(
+        "--html-out",
+        help="Write a standalone HTML viewer to this path and exit (no server).",
+    )
+    view_cmd.add_argument(
+        "--direct",
+        action="store_true",
+        help="Open a standalone file:// HTML viewer instead of starting a server.",
+    )
+    view_cmd.set_defaults(handler=cmd_view)
+
+    record_cmd = subparsers.add_parser(
+        "record",
+        help="Read logs from stdin until termination and write trace JSON.",
+    )
+    record_cmd.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="Output trace JSON path, or '-' for stdout.",
+    )
+    record_cmd.add_argument("--trace-id", help="Override the generated traceId.")
+    record_cmd.set_defaults(handler=cmd_record)
+
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    opener: Opener | None = None,
+) -> int:
+    stdin = stdin if stdin is not None else sys.stdin
+    stdout = stdout if stdout is not None else sys.stdout
+    stderr = stderr if stderr is not None else sys.stderr
+    if opener is None:
+        import webbrowser
+
+        opener = webbrowser.open
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        return args.handler(args, stdin=stdin, stdout=stdout, stderr=stderr, opener=opener)
+    except (OSError, ValueError) as exc:
+        print(f"funcviz: {exc}", file=stderr)
+        return 1
+
+
+def cmd_parse(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: Opener) -> int:
+    text = _read_text_arg(args.input, stdin)
+    trace_id = args.trace_id or _default_trace_id(args.input, text)
+    trace = parse_trace(from_log_text(text), trace_id=trace_id)
+    _write_json(trace.to_dict(), args.output, stdout)
+    return 0
+
+
+def cmd_view(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: Opener) -> int:
+    trace_obj = _read_json_file(args.trace)
+    html_text = _inject_default_trace(_load_viewer_template(), trace_obj)
+
+    if args.html_out:
+        out_path = Path(args.html_out)
+        out_path.write_text(html_text, encoding="utf-8")
+        print(str(out_path), file=stdout)
+        if args.direct:
+            opener(_file_url(out_path))
+        return 0
+
+    if args.direct:
+        path = _write_persistent_temp_html(html_text)
+        print(str(path), file=stdout)
+        opener(_file_url(path))
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="funcviz-view-") as temp_dir:
+        temp_path = Path(temp_dir)
+        (temp_path / "index.html").write_text(html_text, encoding="utf-8")
+        return _serve_directory(
+            temp_path,
+            port=args.port,
+            stdout=stdout,
+            stderr=stderr,
+            opener=opener,
+            no_browser=args.no_browser,
+        )
+
+
+def cmd_record(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: Opener) -> int:
+    chunks: list[str] = []
+    try:
+        while True:
+            chunk = stdin.read(8192)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    except KeyboardInterrupt:
+        print("funcviz: interrupted; writing partial trace.", file=stderr)
+
+    text = "".join(chunks)
+    trace_id = args.trace_id or _hash_trace_id("record", text)
+    trace = parse_trace(from_log_text(text), trace_id=trace_id)
+    _write_json(trace.to_dict(), args.output, stdout)
+    return 0
+
+
+def _read_text_arg(input_arg: str, stdin: TextIO) -> str:
+    if input_arg == "-":
+        return stdin.read()
+    return Path(input_arg).read_text(encoding="utf-8")
+
+
+def _write_text_arg(output_arg: str, text: str, stdout: TextIO) -> None:
+    if output_arg == "-":
+        stdout.write(text)
+        stdout.flush()
+    else:
+        Path(output_arg).write_text(text, encoding="utf-8")
+
+
+def _write_json(obj: object, output_arg: str, stdout: TextIO) -> None:
+    text = json.dumps(obj, indent=2, ensure_ascii=False) + "\n"
+    _write_text_arg(output_arg, text, stdout)
+
+
+def _read_json_file(path_arg: str) -> object:
+    with Path(path_arg).open("r", encoding="utf-8") as handle:
+        try:
+            return json.load(handle)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path_arg}: not valid JSON ({exc})") from exc
+
+
+def _default_trace_id(input_arg: str, text: str) -> str:
+    if input_arg != "-":
+        stem = Path(input_arg).stem
+        if stem:
+            return stem
+    return _hash_trace_id("stdin", text)
+
+
+def _hash_trace_id(prefix: str, text: str) -> str:
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+    return f"{prefix}-{digest}"
+
+
+_DEFAULT_TRACE_RE = re.compile(
+    r'(<script\b(?=[^>]*\bid=["\']funcviz-default-trace["\'])'
+    r'(?=[^>]*\btype=["\']application/json["\'])[^>]*>)'
+    r"(.*?)"
+    r"(</script>)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _json_for_script_tag(obj: object) -> str:
+    """Serialize JSON safe to embed inside an HTML ``<script>`` element."""
+    text = json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
+    return (
+        text.replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def _inject_default_trace(index_html: str, trace_obj: object) -> str:
+    safe_json = _json_for_script_tag(trace_obj)
+    new_html, count = _DEFAULT_TRACE_RE.subn(
+        lambda match: f"{match.group(1)}{safe_json}{match.group(3)}",
+        index_html,
+    )
+    if count != 1:
+        raise ValueError(
+            "viewer template must contain exactly one funcviz-default-trace "
+            f"script tag (found {count})"
+        )
+    return new_html
+
+
+def _load_viewer_template() -> str:
+    return resources.files("funcviz").joinpath("viewer", "index.html").read_text(encoding="utf-8")
+
+
+def _file_url(path: Path) -> str:
+    return "file://" + pathname2url(str(path.resolve()))
+
+
+def _write_persistent_temp_html(html_text: str) -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        suffix=".html",
+        prefix="funcviz-",
+        delete=False,
+    )
+    with handle:
+        handle.write(html_text)
+    return Path(handle.name)
+
+
+def _serve_directory(
+    directory: Path,
+    *,
+    port: int,
+    stdout: TextIO,
+    stderr: TextIO,
+    opener: Opener,
+    no_browser: bool,
+) -> int:
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    with http.server.ThreadingHTTPServer(("127.0.0.1", port), handler) as server:
+        actual_port = server.server_address[1]
+        url = f"http://127.0.0.1:{actual_port}/index.html"
+        print(f"funcviz viewer: {url}", file=stdout)
+        print("Press Ctrl-C to stop.", file=stderr)
+        if not no_browser:
+            opener(url)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("", file=stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,147 @@
+"""CLI behavior tests for ``funcviz`` parse / view / record (issue #8)."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from funcviz import cli
+
+ROOT = Path(__file__).resolve().parent.parent
+SUCCESS_LOG = ROOT / "samples" / "success.log"
+SUCCESS_TRACE = ROOT / "traces" / "success.json"
+
+
+def _run(argv, stdin_text="", opener=None):
+    stdin = io.StringIO(stdin_text)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = cli.main(
+        argv, stdin=stdin, stdout=stdout, stderr=stderr, opener=opener or (lambda url: None)
+    )
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_parse_file_to_output(tmp_path):
+    out = tmp_path / "trace.json"
+    code, _, _ = _run(["parse", str(SUCCESS_LOG), "-o", str(out)])
+    assert code == 0
+    trace = json.loads(out.read_text())
+    assert trace["schemaVersion"] == "0.1"
+    assert trace["traceId"] == "success"
+    assert len(trace["events"]) >= 1
+
+
+def test_parse_stdin_to_stdout():
+    code, stdout, _ = _run(["parse", "-"], stdin_text=SUCCESS_LOG.read_text())
+    assert code == 0
+    trace = json.loads(stdout)
+    assert trace["schemaVersion"] == "0.1"
+
+
+def test_parse_trace_id_from_file_stem(tmp_path):
+    log = tmp_path / "myrun.log"
+    log.write_text(SUCCESS_LOG.read_text())
+    code, stdout, _ = _run(["parse", str(log)])
+    assert code == 0
+    assert json.loads(stdout)["traceId"] == "myrun"
+
+
+def test_parse_stdin_trace_id_is_deterministic_hash():
+    text = SUCCESS_LOG.read_text()
+    _, first, _ = _run(["parse", "-"], stdin_text=text)
+    _, second, _ = _run(["parse", "-"], stdin_text=text)
+    tid = json.loads(first)["traceId"]
+    assert tid == json.loads(second)["traceId"]
+    assert tid.startswith("stdin-")
+
+
+def test_parse_trace_id_override():
+    code, stdout, _ = _run(
+        ["parse", "-", "--trace-id", "custom-42"], stdin_text=SUCCESS_LOG.read_text()
+    )
+    assert code == 0
+    assert json.loads(stdout)["traceId"] == "custom-42"
+
+
+def test_view_html_out_inlines_trace(tmp_path):
+    out = tmp_path / "viewer.html"
+    code, stdout, _ = _run(["view", str(SUCCESS_TRACE), "--html-out", str(out)])
+    assert code == 0
+    assert str(out) in stdout
+    html = out.read_text()
+    assert 'id="funcviz-default-trace"' in html
+    assert '"schemaVersion":"0.1"' in html
+
+
+def test_view_injection_escapes_script_close():
+    trace = {"schemaVersion": "0.1", "note": "</script><!-- x"}
+    template = cli._load_viewer_template()
+    injected = cli._inject_default_trace(template, trace)
+    assert "</script><!--" not in injected.split("funcviz-default-trace")[1][:2000]
+    assert "\\u003c/script\\u003e" in injected
+
+
+def test_view_injection_requires_exactly_one_placeholder():
+    tag = '<script type="application/json" id="funcviz-default-trace">{}</script>'
+    for template in ("<html>no placeholder</html>", tag + tag):
+        try:
+            cli._inject_default_trace(template, {"a": 1})
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass
+
+
+def test_view_direct_opens_file_url(tmp_path):
+    out = tmp_path / "viewer.html"
+    opened = []
+    code, _, _ = _run(
+        ["view", str(SUCCESS_TRACE), "--html-out", str(out), "--direct"],
+        opener=opened.append,
+    )
+    assert code == 0
+    assert opened and opened[0].startswith("file://")
+
+
+def test_view_invalid_json_returns_1(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not json")
+    code, _, stderr = _run(["view", str(bad)])
+    assert code == 1
+    assert "funcviz:" in stderr
+
+
+def test_record_reads_stdin_and_writes(tmp_path):
+    out = tmp_path / "trace.json"
+    code, _, _ = _run(["record", "-o", str(out)], stdin_text=SUCCESS_LOG.read_text())
+    assert code == 0
+    assert json.loads(out.read_text())["schemaVersion"] == "0.1"
+
+
+def test_record_writes_partial_on_keyboard_interrupt(tmp_path):
+    out = tmp_path / "trace.json"
+    text = SUCCESS_LOG.read_text()
+
+    class InterruptingStdin:
+        def __init__(self, payload):
+            self._payload = payload
+            self._served = False
+
+        def read(self, _size=-1):
+            if not self._served:
+                self._served = True
+                return self._payload
+            raise KeyboardInterrupt
+
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = cli.main(
+        ["record", "-o", str(out)],
+        stdin=InterruptingStdin(text),
+        stdout=stdout,
+        stderr=stderr,
+        opener=lambda url: None,
+    )
+    assert code == 0
+    assert json.loads(out.read_text())["schemaVersion"] == "0.1"
+    assert "interrupted" in stderr.getvalue()


### PR DESCRIPTION
## Summary
Implements Issue #8 (PRD §5 / FR-1, FR-3): the `funcviz` CLI in `src/funcviz/cli.py`, pure stdlib, dependencies still empty.

- **`parse <file|->`** — reads a log file or stdin, emits schema-0.1 trace JSON to `-o PATH` or stdout. `traceId` comes from the file stem, a deterministic `stdin-<sha>` hash, or `--trace-id`.
- **`view trace.json`** — inlines the trace into the packaged self-contained viewer (`#funcviz-default-trace` script tag) and serves it from an ephemeral local `http.server` + opens the browser. `--html-out` writes a standalone file, `--direct` opens it over `file://` (no server), `--no-browser`/`--port` for control. Trace JSON is HTML-escaped (`<`,`>`,`&`,U+2028/U+2029) so a `</script>` in the data can't break out of the tag; injection requires **exactly one** placeholder.
- **`record -o trace.json`** — reads stdin until EOF/Ctrl-C and writes whatever was captured (partial trace on interrupt). **No process/PTY supervision** — funcviz only ever reads logs.

`main(argv, *, stdin, stdout, stderr, opener) -> int` uses injectable streams for testability. Only `src/funcviz/cli.py` + `tests/test_cli.py` added.

## Verification
- **Done-when criterion met**: `funcviz view traces/success.json` renders the 3-lane timeline — verified headless (3 lanes, 5 events, 0 console errors) via the generated HTML.
- 12 CLI tests (file/stdin parse, output routing, trace-id stem/hash/override, view `--html-out` inlining, `</script>` escape, exactly-one-placeholder, `--direct` file:// opener, invalid-JSON → exit 1, record EOF, record KeyboardInterrupt partial write). Full suite **62 passed**, ruff clean.
- **Oracle review: 94/100 — MERGE**, no blocking issues. The one worthwhile nit (duplicate-placeholder detection) was addressed in this PR.

Closes #8