### PR TITLE
feat(parser): parse worker-startup failure log into a failure trace (#9)

### DIFF
--- a/src/funcviz/parser/core.py
+++ b/src/funcviz/parser/core.py
@@ -20,7 +20,7 @@ from ..models import (
     TraceInput,
 )
 from ..models import LogRecord as LogRecord
-from .derive import build_intervals, build_lanes, finalize_events
+from .derive import build_failures, build_intervals, build_lanes, finalize_events
 from .events import extract_events
 from .records import fold_http_blocks, record_content
 from .records import from_log_text as _from_log_text
@@ -52,10 +52,11 @@ def parse_trace(
     finalized = finalize_events(raw_events)
     intervals = build_intervals(finalized, raw_events)
     lanes = build_lanes(finalized)
+    failures = build_failures(finalized, raw_events)
 
     meta = _scan_metadata(folded)
     completed = next((r for r in raw_events if r["event"] == "InvocationCompleted"), None)
-    resolved_outcome = _outcome_from(completed) if completed is not None else outcome
+    resolved_outcome = _resolve_outcome(completed, raw_events, outcome)
 
     return Trace(
         trace_id=trace_id,
@@ -72,7 +73,20 @@ def parse_trace(
         events=finalized,
         intervals=intervals,
         application=_application_from(meta),
+        failures=failures,
     )
+
+
+def _resolve_outcome(
+    completed: dict[str, object] | None,
+    raw_events: list[dict[str, object]],
+    fallback: Outcome,
+) -> Outcome:
+    if completed is not None:
+        return _outcome_from(completed)
+    if any(r["event"] == "WorkerIndexingFailed" for r in raw_events):
+        return Outcome.FAILURE
+    return fallback
 
 
 def _application_from(meta: dict[str, str]) -> Application | None:

--- a/src/funcviz/parser/derive.py
+++ b/src/funcviz/parser/derive.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from ..models import (
     Confidence,
     Event,
+    Failure,
     Interval,
     IntervalSource,
     Lane,
@@ -24,6 +25,16 @@ from ..models import (
 
 _CLIENT_REASON = "Derived from host HTTP request/response lines."
 _APPLICATION_REASON = "User-code entry/exit is not separately logged."
+
+_FAIL_CLIENT_REASON = "No HTTP request was observed before worker indexing failed."
+_FAIL_HOST_REASON = (
+    "Host built the app and requested worker metadata; retry-loop logs after the failure "
+    "are omitted."
+)
+_FAIL_WORKER_REASON = "Python worker failed while indexing functions."
+_FAIL_APPLICATION_REASON = (
+    "No invocation reached the function body; indexing failed before the function was loaded."
+)
 
 
 def _to_dt(ts: str) -> datetime:
@@ -121,6 +132,24 @@ def build_intervals(events: list[Event], raw_events: list[dict[str, object]]) ->
 
 
 def build_lanes(events: list[Event]) -> Lanes:
+    failed = next((e for e in events if e.event == "WorkerIndexingFailed"), None)
+    if failed is not None:
+        return Lanes(
+            client=LaneStatus(
+                LaneState.NOT_REACHED, Confidence.OBSERVED, reason=_FAIL_CLIENT_REASON
+            ),
+            host=LaneStatus(LaneState.REACHED, Confidence.OBSERVED, reason=_FAIL_HOST_REASON),
+            python_worker=LaneStatus(
+                LaneState.FAILED_HERE,
+                Confidence.OBSERVED,
+                reason=_FAIL_WORKER_REASON,
+                failure_event=failed.id,
+            ),
+            application=LaneStatus(
+                LaneState.NOT_REACHED, Confidence.OBSERVED, reason=_FAIL_APPLICATION_REASON
+            ),
+        )
+
     names = {e.event for e in events}
     completed = next((e for e in events if e.event == "InvocationCompleted"), None)
     application_reached = completed is not None
@@ -149,6 +178,15 @@ def build_lanes(events: list[Event]) -> Lanes:
             reason=_APPLICATION_REASON,
         ),
     )
+
+
+def build_failures(events: list[Event], raw_events: list[dict[str, object]]) -> list[Failure]:
+    failed = next((e for e in events if e.event == "WorkerIndexingFailed"), None)
+    if failed is None:
+        return []
+    raw_by_name = {str(r["event"]): r for r in raw_events}
+    message = _opt_str(raw_by_name.get("WorkerIndexingFailed", {}).get("failureMessage"))
+    return [Failure(event=failed.id, kind="worker-indexing", message=message)]
 
 
 def _as_lane(value: object) -> Lane:

--- a/src/funcviz/parser/events.py
+++ b/src/funcviz/parser/events.py
@@ -1,10 +1,13 @@
-"""Extract the five frozen events from folded records, in log order.
+"""Extract lifecycle events from folded records, in log order.
 
-The event vocabulary is exactly what survived the Phase 0 coverage matrix
+The success vocabulary is exactly what survived the Phase 0 coverage matrix
 (docs/event-coverage.md): HttpRequestReceived, InvocationStarted,
-WorkerReceivedInvocation, InvocationCompleted, HttpResponseReturned. This stage
-owns no regexes; it delegates every log-shape decision to :mod:`.regexes` and
-emits order-preserving intermediate dicts that :mod:`.derive` finalizes.
+WorkerReceivedInvocation, InvocationCompleted, HttpResponseReturned. A log with
+no invocation (issue #9) instead yields the worker-startup failure vocabulary:
+HostBuildStarted, WorkerIndexingStarted, PythonWorkerStarted,
+WorkerMetadataRequested, WorkerIndexingFailed. This stage owns no regexes; it
+delegates every log-shape decision to :mod:`.regexes` and emits order-preserving
+intermediate dicts that :mod:`.derive` finalizes.
 """
 
 from __future__ import annotations
@@ -16,15 +19,30 @@ from .records import record_content, record_timestamp
 from .regexes import (
     find_http_duration,
     find_http_request_id,
+    find_module_not_found,
+    is_host_build_started,
     is_http_request_start,
     is_http_response_start,
+    is_python_worker_started,
+    is_worker_failed_to_index,
+    is_worker_indexing_started,
     match_invocation_completed,
     match_invocation_started,
     match_worker_invocation,
+    match_worker_metadata_request,
 )
 
 
 def extract_events(folded: Iterable[LogRecord]) -> list[dict[str, object]]:
+    records = list(folded)
+    success = extract_success_events(records)
+    if any(e["event"] == "InvocationCompleted" for e in success):
+        return success
+    failure = extract_worker_startup_failure_events(records)
+    return failure or success
+
+
+def extract_success_events(folded: Iterable[LogRecord]) -> list[dict[str, object]]:
     events: list[dict[str, object]] = []
     for record in folded:
         content = record_content(record)
@@ -104,4 +122,68 @@ def extract_events(folded: Iterable[LogRecord]) -> list[dict[str, object]]:
             )
             continue
 
+    return events
+
+
+def extract_worker_startup_failure_events(
+    folded: Iterable[LogRecord],
+) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    seen: set[str] = set()
+    module_message: str | None = None
+
+    def emit(name: str, lane: Lane, record: LogRecord, ts: str, **extra: object) -> None:
+        if name in seen:
+            return
+        seen.add(name)
+        events.append(
+            {
+                "event": name,
+                "lane": lane,
+                "confidence": Confidence.OBSERVED,
+                "timestamp": ts,
+                "raw": record.message,
+                **extra,
+            }
+        )
+
+    for record in folded:
+        content = record_content(record)
+        ts = record_timestamp(record)
+
+        module = find_module_not_found(content)
+        if module is not None and module_message is None:
+            module_message = f"ModuleNotFoundError: No module named '{module}'"
+
+        if is_host_build_started(content):
+            emit("HostBuildStarted", Lane.HOST, record, ts)
+            continue
+        if is_worker_indexing_started(content):
+            emit("WorkerIndexingStarted", Lane.HOST, record, ts)
+            continue
+        if is_python_worker_started(content):
+            emit("PythonWorkerStarted", Lane.PYTHON_WORKER, record, ts)
+            continue
+        metadata = match_worker_metadata_request(content)
+        if metadata is not None:
+            emit(
+                "WorkerMetadataRequested",
+                Lane.PYTHON_WORKER,
+                record,
+                ts,
+                workerRequestId=metadata["worker"],
+            )
+            continue
+        if is_worker_failed_to_index(content):
+            emit(
+                "WorkerIndexingFailed",
+                Lane.PYTHON_WORKER,
+                record,
+                ts,
+                failureMessage=module_message,
+            )
+            break
+
+    if "WorkerIndexingFailed" not in seen:
+        return []
     return events

--- a/src/funcviz/parser/regexes.py
+++ b/src/funcviz/parser/regexes.py
@@ -33,6 +33,15 @@ _HTTP_DURATION = re.compile(r'"duration":\s*"(?P<duration>\d+)"')
 _HTTP_REQUEST_START = "Executing HTTP request:"
 _HTTP_RESPONSE_START = "Executed HTTP request:"
 
+_HOST_BUILD_STARTED = "Building host:"
+_WORKER_INDEXING_ENABLED = "Worker indexing is enabled"
+_PYTHON_WORKER_STARTED = "Starting Azure Functions Python Worker"
+_WORKER_FAILED_TO_INDEX = "Worker failed to index functions"
+_WORKER_METADATA_REQUEST = re.compile(
+    r"Received WorkerMetadataRequest, request ID:?\s*(?P<worker>[0-9a-fA-F-]{36})"
+)
+_MODULE_NOT_FOUND = re.compile(r"ModuleNotFoundError: No module named '(?P<module>[^']+)'")
+
 
 def split_timestamp(line: str) -> tuple[str | None, str]:
     m = _TIMESTAMP.match(line)
@@ -47,6 +56,32 @@ def is_http_request_start(content: str) -> bool:
 
 def is_http_response_start(content: str) -> bool:
     return content.startswith(_HTTP_RESPONSE_START)
+
+
+def is_host_build_started(content: str) -> bool:
+    return content.startswith(_HOST_BUILD_STARTED)
+
+
+def is_worker_indexing_started(content: str) -> bool:
+    return content.startswith(_WORKER_INDEXING_ENABLED)
+
+
+def is_python_worker_started(content: str) -> bool:
+    return _PYTHON_WORKER_STARTED in content
+
+
+def is_worker_failed_to_index(content: str) -> bool:
+    return content.startswith(_WORKER_FAILED_TO_INDEX)
+
+
+def match_worker_metadata_request(content: str) -> dict[str, str] | None:
+    m = _WORKER_METADATA_REQUEST.search(content)
+    return m.groupdict() if m else None
+
+
+def find_module_not_found(content: str) -> str | None:
+    m = _MODULE_NOT_FOUND.search(content)
+    return m.group("module") if m else None
 
 
 def match_invocation_started(content: str) -> dict[str, str] | None:

--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -254,6 +254,7 @@
     color: var(--fail); border: 1px dashed rgba(248,81,73,.5);
     border-radius: var(--radius-sm); padding: var(--sp-2) var(--sp-3);
   }
+  .event.is-failure { border-color: rgba(248,81,73,.6); box-shadow: inset 3px 0 0 var(--fail); }
 
   /* ============================================================
      events — ordered cards, observed vs inferred redundant cues
@@ -735,11 +736,21 @@
       }
       if (laneEvents.length) {
         laneEvents.forEach(function (ev) {
-          list.appendChild(renderEvent(ev, ev.id === selectedEventId));
+          var isFailure = status === "failed-here" && ev.id === meta.failureEvent;
+          var card = renderEvent(ev, ev.id === selectedEventId);
+          var stopHere;
+          if (isFailure) card.classList.add("is-failure");
+          list.appendChild(card);
+          if (isFailure) {
+            stopHere = el("li", "lane-stop", "⨯ Run stopped here — worker did not continue past this point");
+            stopHere.setAttribute("data-stop-after", ev.id);
+            list.appendChild(stopHere);
+          }
         });
         body.appendChild(list);
       }
-      if (status === "failed-here") {
+      var failureAnchored = laneEvents.some(function (ev) { return ev.id === meta.failureEvent; });
+      if (status === "failed-here" && !failureAnchored) {
         body.appendChild(el("div", "lane-stop", "⨯ Run stopped in this lane"));
       }
       section.appendChild(body);
@@ -1143,7 +1154,9 @@
       return;
     }
     renderTrace(res.trace);
-    if (!quiet) setStatus("Restored built-in default trace.", "ok");
+    var summary = "Showing embedded trace (" + (res.trace.traceId || "unknown") + ") — " +
+      res.trace.events.length + " events, outcome: " + (res.trace.outcome || "?") + ".";
+    setStatus(quiet ? summary : "Restored default trace — " + summary, "ok");
   }
 
   /* ---------------- wiring ----------------------------------------------- */
@@ -1241,7 +1254,6 @@
   };
 
   loadDefaultTrace(true);
-  setStatus("Showing built-in default trace (success-001) — 5 events.", "ok");
 })();
 </script>
 

--- a/tests/test_parser_worker_fail.py
+++ b/tests/test_parser_worker_fail.py
@@ -1,0 +1,110 @@
+"""Failure-trace derivation for the worker startup/indexing case (issue #9).
+
+Asserts that ``worker-fail.log`` (a worker that crashed while indexing, before
+any HTTP request or invocation) parses into a schema-valid ``outcome: failure``
+trace that stops honestly at the indexing failure: the python-worker lane owns
+the stop, client and application are not reached, and the post-failure host
+retry loop is not rendered as forward progress (PRD FR-9). A byte-for-byte
+golden guards the committed ``traces/worker-fail.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from funcviz.parser import from_log_text, parse_trace
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
+
+FAILURE_EVENTS = [
+    "HostBuildStarted",
+    "WorkerIndexingStarted",
+    "PythonWorkerStarted",
+    "WorkerMetadataRequested",
+    "WorkerIndexingFailed",
+]
+
+RETRY_LOOP_MARKERS = ["Starting Host", "0 functions found"]
+
+
+def _parsed() -> dict[str, object]:
+    text = (ROOT / "samples" / "worker-fail.log").read_text()
+    return parse_trace(from_log_text(text), trace_id="worker-fail-001").to_dict()
+
+
+def test_failure_log_validates_against_schema():
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(_parsed()))
+
+
+def test_outcome_is_failure_without_an_executed_failed_line():
+    assert _parsed()["outcome"] == "failure"
+
+
+def test_event_vocabulary_and_order():
+    events = _parsed()["events"]
+    assert [e["event"] for e in events] == FAILURE_EVENTS
+    assert [e["sequence"] for e in events] == [0, 1, 2, 3, 4]
+
+
+def test_no_http_or_invocation_events_leak_in():
+    names = {e["event"] for e in _parsed()["events"]}
+    forbidden = {
+        "HttpRequestReceived",
+        "HttpResponseReturned",
+        "InvocationStarted",
+        "InvocationCompleted",
+        "WorkerReceivedInvocation",
+    }
+    assert not (names & forbidden)
+
+
+def test_python_worker_lane_owns_the_stop():
+    lanes = _parsed()["lanes"]
+    assert lanes["python-worker"]["status"] == "failed-here"
+    assert lanes["python-worker"]["failureEvent"] == "e4"
+
+
+def test_client_and_application_lanes_are_not_reached():
+    lanes = _parsed()["lanes"]
+    assert lanes["client"]["status"] == "not-reached"
+    assert lanes["application"]["status"] == "not-reached"
+    assert lanes["host"]["status"] == "reached"
+
+
+def test_host_is_not_marked_failed():
+    assert _parsed()["lanes"]["host"]["status"] != "failed-here"
+
+
+def test_failure_record_references_the_terminal_event():
+    failures = _parsed()["failures"]
+    assert failures == [
+        {
+            "event": "e4",
+            "kind": "worker-indexing",
+            "message": "ModuleNotFoundError: No module named 'this_module_does_not_exist'",
+        }
+    ]
+
+
+def test_no_intervals_for_a_run_that_never_invoked():
+    assert _parsed()["intervals"] == []
+
+
+def test_no_application_block_when_the_function_never_loaded():
+    assert "application" not in _parsed()
+
+
+def test_retry_loop_after_failure_is_not_rendered_as_events():
+    for event in _parsed()["events"]:
+        raw = event["raw"] or ""
+        for marker in RETRY_LOOP_MARKERS:
+            assert marker not in raw, marker
+
+
+def test_parser_output_matches_committed_golden():
+    golden = json.loads((ROOT / "traces" / "worker-fail.json").read_text())
+    assert _parsed() == golden

--- a/tests/test_parser_worker_fail_regexes.py
+++ b/tests/test_parser_worker_fail_regexes.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 
-import pytest
-
 from funcviz.parser import from_log_text, parse_trace
 from funcviz.parser.regexes import (
     find_core_tools_version,
@@ -71,7 +69,14 @@ def test_failure_shape_markers_are_still_present():
         assert marker in text, marker
 
 
-def test_success_parser_cannot_yet_build_a_trace_from_failure_log():
+def test_failure_log_builds_a_failure_trace():
     text = (ROOT / "samples" / "worker-fail.log").read_text()
-    with pytest.raises(ValueError):
-        parse_trace(from_log_text(text), trace_id="worker-fail-001")
+    doc = parse_trace(from_log_text(text), trace_id="worker-fail-001").to_dict()
+    assert doc["outcome"] == "failure"
+    assert [e["event"] for e in doc["events"]] == [
+        "HostBuildStarted",
+        "WorkerIndexingStarted",
+        "PythonWorkerStarted",
+        "WorkerMetadataRequested",
+        "WorkerIndexingFailed",
+    ]

--- a/traces/worker-fail.json
+++ b/traces/worker-fail.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": "0.1",
+  "traceId": "worker-fail-001",
+  "outcome": "failure",
+  "input": {
+    "source": "core-tools-log",
+    "adapter": "CoreToolsLogAdapter",
+    "adapterVersion": "0.1"
+  },
+  "runtime": {
+    "environment": "local",
+    "language": "python",
+    "trigger": "http",
+    "coreToolsVersion": "4.6.0+ab90faafcab539d63cd3d0ce5faf1bca4395fccc",
+    "hostVersion": "4.1045.200.25556"
+  },
+  "lanes": {
+    "client": {
+      "status": "not-reached",
+      "confidence": "observed",
+      "reason": "No HTTP request was observed before worker indexing failed."
+    },
+    "host": {
+      "status": "reached",
+      "confidence": "observed",
+      "reason": "Host built the app and requested worker metadata; retry-loop logs after the failure are omitted."
+    },
+    "python-worker": {
+      "status": "failed-here",
+      "confidence": "observed",
+      "reason": "Python worker failed while indexing functions.",
+      "failureEvent": "e4"
+    },
+    "application": {
+      "status": "not-reached",
+      "confidence": "observed",
+      "reason": "No invocation reached the function body; indexing failed before the function was loaded."
+    }
+  },
+  "events": [
+    {
+      "id": "e0",
+      "sequence": 0,
+      "timestamp": "2026-09-05T00:45:57.407Z",
+      "elapsedMs": 0,
+      "lane": "host",
+      "event": "HostBuildStarted",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:57.407Z] Building host: version spec: , startup suppressed: 'False', configuration suppressed: 'False', startup operation id: 'bf56153b-c386-4502-b9d3-3ffb7acace98'"
+    },
+    {
+      "id": "e1",
+      "sequence": 1,
+      "timestamp": "2026-09-05T00:45:57.523Z",
+      "elapsedMs": 116,
+      "lane": "host",
+      "event": "WorkerIndexingStarted",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:57.523Z] Worker indexing is enabled"
+    },
+    {
+      "id": "e2",
+      "sequence": 2,
+      "timestamp": "2026-09-05T00:45:57.785Z",
+      "elapsedMs": 378,
+      "lane": "python-worker",
+      "event": "PythonWorkerStarted",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:57.785Z]  INFO: Starting Azure Functions Python Worker."
+    },
+    {
+      "id": "e3",
+      "sequence": 3,
+      "timestamp": "2026-09-05T00:46:00.290Z",
+      "elapsedMs": 2883,
+      "lane": "python-worker",
+      "event": "WorkerMetadataRequested",
+      "workerRequestId": "f7d72cf7-a231-4fe8-a0b2-7d8b1d58bc8a",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:46:00.290Z] Received WorkerMetadataRequest, request ID f7d72cf7-a231-4fe8-a0b2-7d8b1d58bc8a, function_path: /Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/function_app.py"
+    },
+    {
+      "id": "e4",
+      "sequence": 4,
+      "timestamp": "2026-09-05T00:46:00.349Z",
+      "elapsedMs": 2942,
+      "lane": "python-worker",
+      "event": "WorkerIndexingFailed",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:46:00.349Z] Worker failed to index functions"
+    }
+  ],
+  "intervals": [],
+  "failures": [
+    {
+      "event": "e4",
+      "kind": "worker-indexing",
+      "message": "ModuleNotFoundError: No module named 'this_module_does_not_exist'"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements issue #9: turn a Python worker **indexing/startup failure** log (no invocation ever runs) into a first-class failure trace and render it in the viewer with the failure lane stop anchored to the failing event.

- Adds a second extraction path (`extract_worker_startup_failure_events`) that emits exactly five observed events — `HostBuildStarted`, `WorkerIndexingStarted`, `PythonWorkerStarted`, `WorkerMetadataRequested`, `WorkerIndexingFailed` — and **stops at the terminal failure**, so the host retry loop (`Starting Host`, `0 functions found`) is never rendered as forward progress.
- Failure-shape lanes: `host=reached`, `python-worker=failed-here` (with `failure_event`), `client`/`application`=`not-reached`; plus a `failures` record `{event, kind: worker-indexing, message: ModuleNotFoundError...}`; `outcome=failure`; `intervals=[]`.
- `extract_events` prefers the failure branch only when there is **no terminal `InvocationCompleted`** (guards against partial-success logs).
- Viewer: `.event.is-failure` highlight + `⨯ Run stopped here` marker anchored to `lane.failureEvent`; boot banner now derived from the embedded trace instead of a hardcoded `success-001` line.
- `traces/worker-fail.json` is generated **from the parser**, not hand-written. No schema change.

## Verification
- 74 tests pass (12 new), `ruff` clean, LSP clean.
- Headless DOM checks on the generated viewer: events ordered `e0→e4`, lanes correct, single `is-failure` card (e4), single `lane-stop[data-stop-after=e4]`, `outcome=failure`, no retry-loop text in any rendered `data-raw`, 0 console errors.
- Oracle review: **92/100**, no release-blocking defects; the two cheap robustness items (partial-success guard, defensive `.get`) applied.

Closes #9