### PR TITLE
feat(parser): mask secrets in logs by default with --no-mask opt-out (#11)

### DIFF
--- a/samples/success.log
+++ b/samples/success.log
@@ -323,7 +323,8 @@ Functions:
 [2026-09-05T00:45:16.955Z]   "requestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
 [2026-09-05T00:45:16.955Z]   "method": "GET",
 [2026-09-05T00:45:16.955Z]   "userAgent": "curl/8.7.1",
-[2026-09-05T00:45:16.955Z]   "uri": "/api/hello"
+[2026-09-05T00:45:16.955Z]   "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.FAKEpayload.FAKEsignature",
+[2026-09-05T00:45:16.955Z]   "uri": "/api/hello?code=Zm9vYmFyZmFrZWZ1bmN0aW9ua2V5MTIzNDU2Nzg5MA=="
 [2026-09-05T00:45:16.955Z] }
 [2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='This function was programmatically called via the host APIs.', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)
 [2026-09-05T00:45:17.227Z] Received FunctionInvocationRequest, request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, function ID: 4d71d03f-f19b-5d9e-8523-9628ba18063c, function name: hello, invocation ID: 6a8f3658-2b31-4554-aa86-1ee32a9e679b, function type: sync, timestamp (UTC): 2026-09-05 00:45:17.226806, sync threadpool max workers: 1000

--- a/samples/worker-fail.log
+++ b/samples/worker-fail.log
@@ -21,7 +21,7 @@ Azure Functions Core Tools
 Core Tools Version:       4.6.0+ab90faafcab539d63cd3d0ce5faf1bca4395fccc (64-bit)
 Function Runtime Version: 4.1045.200.25556
 
-[2026-09-05T00:45:57.407Z] Building host: version spec: , startup suppressed: 'False', configuration suppressed: 'False', startup operation id: 'bf56153b-c386-4502-b9d3-3ffb7acace98'
+[2026-09-05T00:45:57.407Z] Building host: version spec: , startup suppressed: 'False', configuration suppressed: 'False', startup operation id: 'bf56153b-c386-4502-b9d3-3ffb7acace98', AzureWebJobsStorage=DefaultEndpointsProtocol=https;AccountName=funcstore01;AccountKey=Zm9vYmFyYmF6c2VjcmV0c3RvcmFnZWtleTk4NzY1NDMyMTA=;EndpointSuffix=core.windows.net
 [2026-09-05T00:45:57.483Z] Reading host configuration file '/Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/host.json'
 [2026-09-05T00:45:57.484Z] Host configuration file read:
 [2026-09-05T00:45:57.484Z] {

--- a/src/funcviz/cli.py
+++ b/src/funcviz/cli.py
@@ -15,7 +15,6 @@ import functools
 import hashlib
 import http.server
 import json
-import re
 import sys
 import tempfile
 from collections.abc import Callable
@@ -24,7 +23,8 @@ from pathlib import Path
 from typing import TextIO
 from urllib.request import pathname2url
 
-from funcviz.parser import from_log_text, parse_trace
+from funcviz.models import LogRecord
+from funcviz.parser import from_log_text, mask_records, parse_trace
 
 Opener = Callable[[str], object]
 
@@ -48,6 +48,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output trace JSON path, or '-' for stdout (default: stdout).",
     )
     parse_cmd.add_argument("--trace-id", help="Override the generated traceId.")
+    parse_cmd.add_argument(
+        "--no-mask",
+        action="store_true",
+        help="Do not redact secrets; emit raw log text verbatim (masking is on by default).",
+    )
     parse_cmd.set_defaults(handler=cmd_parse)
 
     view_cmd = subparsers.add_parser(
@@ -88,6 +93,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output trace JSON path, or '-' for stdout.",
     )
     record_cmd.add_argument("--trace-id", help="Override the generated traceId.")
+    record_cmd.add_argument(
+        "--no-mask",
+        action="store_true",
+        help="Do not redact secrets; emit raw log text verbatim (masking is on by default).",
+    )
     record_cmd.set_defaults(handler=cmd_record)
 
     return parser
@@ -122,7 +132,7 @@ def main(
 def cmd_parse(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: Opener) -> int:
     text = _read_text_arg(args.input, stdin)
     trace_id = args.trace_id or _default_trace_id(args.input, text)
-    trace = parse_trace(from_log_text(text), trace_id=trace_id)
+    trace = parse_trace(_records(text, no_mask=args.no_mask), trace_id=trace_id)
     _write_json(trace.to_dict(), args.output, stdout)
     return 0
 
@@ -171,9 +181,14 @@ def cmd_record(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: O
 
     text = "".join(chunks)
     trace_id = args.trace_id or _hash_trace_id("record", text)
-    trace = parse_trace(from_log_text(text), trace_id=trace_id)
+    trace = parse_trace(_records(text, no_mask=args.no_mask), trace_id=trace_id)
     _write_json(trace.to_dict(), args.output, stdout)
     return 0
+
+
+def _records(text: str, *, no_mask: bool) -> list[LogRecord]:
+    records = from_log_text(text)
+    return records if no_mask else mask_records(records)
 
 
 def _read_text_arg(input_arg: str, stdin: TextIO) -> str:
@@ -216,13 +231,7 @@ def _hash_trace_id(prefix: str, text: str) -> str:
     return f"{prefix}-{digest}"
 
 
-_DEFAULT_TRACE_RE = re.compile(
-    r'(<script\b(?=[^>]*\bid=["\']funcviz-default-trace["\'])'
-    r'(?=[^>]*\btype=["\']application/json["\'])[^>]*>)'
-    r"(.*?)"
-    r"(</script>)",
-    re.IGNORECASE | re.DOTALL,
-)
+_DEFAULT_TRACE_ID = "funcviz-default-trace"
 
 
 def _json_for_script_tag(obj: object) -> str:
@@ -237,18 +246,34 @@ def _json_for_script_tag(obj: object) -> str:
     )
 
 
-def _inject_default_trace(index_html: str, trace_obj: object) -> str:
-    safe_json = _json_for_script_tag(trace_obj)
-    new_html, count = _DEFAULT_TRACE_RE.subn(
-        lambda match: f"{match.group(1)}{safe_json}{match.group(3)}",
-        index_html,
-    )
-    if count != 1:
+def _find_default_trace_script(index_html: str) -> tuple[int, int]:
+    matches: list[tuple[int, int]] = []
+    search = 0
+    while True:
+        open_start = index_html.find("<script", search)
+        if open_start == -1:
+            break
+        open_end = index_html.find(">", open_start)
+        if open_end == -1:
+            break
+        tag = index_html[open_start : open_end + 1]
+        if _DEFAULT_TRACE_ID in tag and "application/json" in tag:
+            close_start = index_html.find("</script>", open_end)
+            if close_start != -1:
+                matches.append((open_end + 1, close_start))
+        search = open_end + 1
+    if len(matches) != 1:
         raise ValueError(
             "viewer template must contain exactly one funcviz-default-trace "
-            f"script tag (found {count})"
+            f"script tag (found {len(matches)})"
         )
-    return new_html
+    return matches[0]
+
+
+def _inject_default_trace(index_html: str, trace_obj: object) -> str:
+    safe_json = _json_for_script_tag(trace_obj)
+    body_start, body_end = _find_default_trace_script(index_html)
+    return index_html[:body_start] + "\n" + safe_json + "\n" + index_html[body_end:]
 
 
 def _load_viewer_template() -> str:

--- a/src/funcviz/parser/__init__.py
+++ b/src/funcviz/parser/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from .core import from_log_text, parse_trace
+from .masking import mask_records, mask_text
 
-__all__ = ["from_log_text", "parse_trace"]
+__all__ = ["from_log_text", "mask_records", "mask_text", "parse_trace"]

--- a/src/funcviz/parser/masking.py
+++ b/src/funcviz/parser/masking.py
@@ -1,0 +1,55 @@
+"""Secret redaction for log text before a trace leaves the machine (PRD §16).
+
+A trace embeds raw log lines and may be pasted into an issue or shown in a
+presentation, so v0.1 masks the four secret classes §16 names -- authorization
+headers, function keys, connection strings, and storage/shared-access
+credentials -- as a pure, parse-time regex pass. Every match keeps its
+surrounding key visible and replaces only the secret *value* with a typed
+``[REDACTED:kind]`` marker, so a redacted trace announces what it hid rather
+than silently dropping content (a quietly shortened trace is worse than one
+that shows the redaction).
+
+The pass is pure and standalone: the CLI applies it to records *before*
+``parse_trace`` (default on, ``--no-mask`` off), keeping the parser itself free
+of redaction policy. Masking rewrites both ``LogRecord.message`` (which becomes
+each event's ``raw``) and ``fields["content"]`` (which extraction reads), and is
+scoped so it never touches the invocation IDs, durations, status codes, ports,
+or GUIDs the extractor depends on. Re-masking already-masked text is a no-op.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ..models import LogRecord
+from .regexes import redact_secrets
+
+
+def mask_text(text: str) -> str:
+    """Redact every known secret value in ``text``; idempotent on marked text.
+
+    The redaction patterns live in :mod:`.regexes` (the parser's sole ``re``
+    owner, PRD R1); this thin wrapper keeps masking's public name stable.
+    """
+    return redact_secrets(text)
+
+
+def mask_record(record: LogRecord) -> LogRecord:
+    """Return a copy of ``record`` with secrets masked in message and content."""
+    fields = dict(record.fields)
+    content = fields.get("content")
+    if isinstance(content, str):
+        fields["content"] = mask_text(content)
+    return LogRecord(
+        message=mask_text(record.message),
+        timestamp=record.timestamp,
+        fields=fields,
+    )
+
+
+def mask_records(records: Iterable[LogRecord]) -> list[LogRecord]:
+    """Mask secrets across a stream of records (see :func:`mask_record`)."""
+    return [mask_record(record) for record in records]
+
+
+__all__ = ["mask_record", "mask_records", "mask_text"]

--- a/src/funcviz/parser/regexes.py
+++ b/src/funcviz/parser/regexes.py
@@ -132,3 +132,101 @@ def find_runtime_version(content: str) -> str | None:
 def find_function_path(content: str) -> str | None:
     m = _FUNCTION_PATH.search(content)
     return m.group("path") if m else None
+
+
+# ---- secret redaction (issue #11, PRD §16) -------------------------------
+# Value-capture classes stop at the delimiters that bound a secret in a log
+# line or a folded multiline JSON block, so a match never spills across quotes,
+# separators, or line breaks into a neighbouring field.
+_HEADER_VALUE = r"[^\s\"',}\r\n]+"
+_QUERY_VALUE = r"[^\s\"'&,;}#\r\n]+"
+_CONN_VALUE = r"[^;\s\"',}\r\n]+"
+
+# Optional quote around a header key or the start of its value, so the same
+# rule covers both flat log lines (Authorization: Bearer x) and folded JSON
+# blocks ("Authorization": "Bearer x"). The quote stays in the kept prefix.
+_Q = r"[\"']?"
+
+# A generic (non-Bearer/Basic) Authorization value can carry an arbitrary
+# scheme with embedded spaces (ApiKey secret, Digest realm="x", ...), so it is
+# redacted whole rather than only its first whitespace-delimited token, which
+# would leak the credential tail. A JSON-quoted value stops at its closing
+# quote; an unquoted value runs to end-of-line (which may contain its own
+# embedded quotes, e.g. Digest). Both require a non-whitespace first character
+# so the separator's trailing \s* cannot backtrack and expose the negative
+# lookahead to a leading space -- that backtrack would otherwise let the rule
+# re-swallow an already Bearer/Basic-masked value and drop the ': "' separator.
+_AUTH_QUOTED_VALUE = r"[^\s\"'\r\n][^\"'\r\n]*"
+_AUTH_LINE_VALUE = r"[^\s\r\n][^\r\n]*"
+
+# (pattern, replacement) pairs applied in order. Bearer/Basic run before the
+# generic Authorization rule -- whose negative lookahead then skips those
+# schemes and any existing marker -- so each secret gets one typed marker and
+# re-masking is a no-op (a value class re-captures a whole marker and rewrites
+# it to itself). Every rule keeps its key visible and redacts only the value,
+# and none of the classes overlap the invocation IDs, durations, status codes,
+# ports, or GUIDs the extractor depends on.
+_REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"(" + _Q + r"Authorization" + _Q + r"\s*:\s*" + _Q + r"Bearer\s+)" + _HEADER_VALUE,
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:bearer-token]",
+    ),
+    (
+        re.compile(
+            r"(" + _Q + r"Authorization" + _Q + r"\s*:\s*" + _Q + r"Basic\s+)" + _HEADER_VALUE,
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:basic-auth]",
+    ),
+    (
+        re.compile(
+            r"(" + _Q + r"Authorization" + _Q + r"\s*:\s*[\"'])"
+            r"(?!Bearer\b|Basic\b|\[REDACTED)" + _AUTH_QUOTED_VALUE,
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:authorization]",
+    ),
+    (
+        re.compile(
+            r"(" + _Q + r"Authorization" + _Q + r"\s*:\s*)"
+            r"(?![\"']|Bearer\b|Basic\b|\[REDACTED)" + _AUTH_LINE_VALUE,
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:authorization]",
+    ),
+    (
+        re.compile(r"([?&](?:code|x-functions-key)=)" + _QUERY_VALUE, re.IGNORECASE),
+        r"\1[REDACTED:function-key]",
+    ),
+    (
+        re.compile(
+            r"(" + _Q + r"x-functions-key" + _Q + r"\s*:\s*" + _Q + r")" + _HEADER_VALUE,
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:function-key]",
+    ),
+    (re.compile(r"(AccountKey=)" + _CONN_VALUE, re.IGNORECASE), r"\1[REDACTED:storage-key]"),
+    (
+        re.compile(r"(SharedAccessKey=)(?!Name=)" + _CONN_VALUE, re.IGNORECASE),
+        r"\1[REDACTED:shared-access-key]",
+    ),
+    (re.compile(r"([?&;]sig=)" + _QUERY_VALUE, re.IGNORECASE), r"\1[REDACTED:sas]"),
+    (re.compile(r"(SharedAccessSignature=)" + _CONN_VALUE, re.IGNORECASE), r"\1[REDACTED:sas]"),
+    # Generic connection-string secrets (semicolon-delimited). AccessKey= is
+    # guarded so it never re-fires on the tail of SharedAccessKey=.
+    (re.compile(r"((?:Password|Pwd)=)" + _CONN_VALUE, re.IGNORECASE), r"\1[REDACTED:password]"),
+    (re.compile(r"(ClientSecret=)" + _CONN_VALUE, re.IGNORECASE), r"\1[REDACTED:client-secret]"),
+    (
+        re.compile(r"(?<![A-Za-z])(AccessKey=)" + _CONN_VALUE, re.IGNORECASE),
+        r"\1[REDACTED:access-key]",
+    ),
+)
+
+
+def redact_secrets(content: str) -> str:
+    for pattern, replacement in _REDACTIONS:
+        content = pattern.sub(replacement, content)
+    return content

--- a/tests/test_parser_contracts.py
+++ b/tests/test_parser_contracts.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from funcviz.parser import from_log_text, parse_trace
+from funcviz.parser import from_log_text, mask_records, parse_trace
 
 ROOT = Path(__file__).resolve().parent.parent
 HTTP_REQUEST_ID = "2d0db691-8e70-4335-a8a9-e127715fa678"
@@ -21,7 +21,7 @@ INVOCATION_ID = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
 
 def _trace() -> dict[str, object]:
     text = (ROOT / "samples" / "success.log").read_text()
-    return parse_trace(from_log_text(text), trace_id="success-001").to_dict()
+    return parse_trace(mask_records(from_log_text(text)), trace_id="success-001").to_dict()
 
 
 def _events() -> list[dict[str, object]]:

--- a/tests/test_parser_masking.py
+++ b/tests/test_parser_masking.py
@@ -1,0 +1,178 @@
+"""Secret redaction pass tests (issue #11, PRD §16).
+
+Covers the pure ``masking`` module (each secret class, idempotency, both record
+fields) and the CLI contract that parsing masks by default while ``--no-mask``
+emits raw text verbatim.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from funcviz import cli
+from funcviz.models import LogRecord
+from funcviz.parser import mask_records, mask_text
+
+ROOT = Path(__file__).resolve().parent.parent
+SUCCESS_LOG = ROOT / "samples" / "success.log"
+WORKER_FAIL_LOG = ROOT / "samples" / "worker-fail.log"
+
+
+def test_masks_quoted_json_header_forms():
+    cases = {
+        '"Authorization": "Bearer eyJ.abc.def"': (
+            '"Authorization": "Bearer [REDACTED:bearer-token]"'
+        ),
+        '"Authorization": "Basic dXNlcjpwYXNz"': '"Authorization": "Basic [REDACTED:basic-auth]"',
+        '"x-functions-key": "secretkey123"': '"x-functions-key": "[REDACTED:function-key]"',
+        "'Authorization': 'Bearer tok'": "'Authorization': 'Bearer [REDACTED:bearer-token]'",
+    }
+    for raw, expected in cases.items():
+        assert mask_text(raw) == expected, raw
+
+
+def test_masks_generic_authorization_scheme_with_spaces():
+    cases = {
+        "Authorization: ApiKey secret123": "Authorization: [REDACTED:authorization]",
+        '"Authorization": "ApiKey secret123"': '"Authorization": "[REDACTED:authorization]"',
+        'Authorization: Digest username="u", response="secretsig"': (
+            "Authorization: [REDACTED:authorization]"
+        ),
+    }
+    for raw, expected in cases.items():
+        masked = mask_text(raw)
+        assert masked == expected, raw
+        assert "secret" not in masked
+
+
+def test_masks_generic_connection_string_secrets():
+    cases = {
+        "Server=db;Password=hunter2;Db=x": "Server=db;Password=[REDACTED:password];Db=x",
+        "User Id=sa;Pwd=s3cr3t;": "User Id=sa;Pwd=[REDACTED:password];",
+        "ClientSecret=abc~def.ghi;Tenant=t": "ClientSecret=[REDACTED:client-secret];Tenant=t",
+        "Endpoint=x;AccessKey=zzz111;": "Endpoint=x;AccessKey=[REDACTED:access-key];",
+    }
+    for raw, expected in cases.items():
+        assert mask_text(raw) == expected, raw
+
+
+def test_access_key_rule_does_not_refire_on_shared_access_key():
+    text = "SharedAccessKey=abc123;Entity=q"
+    assert mask_text(text) == "SharedAccessKey=[REDACTED:shared-access-key];Entity=q"
+
+
+def test_masks_folded_multiline_http_block():
+    block = (
+        "Executing HTTP request: {\n"
+        '  "requestId": "2d0db691-8e70-4335-a8a9-e127715fa678",\n'
+        '  "Authorization": "Bearer eyJ.leak.sig",\n'
+        '  "uri": "/api/hello?code=leakedkey123"\n'
+        "}"
+    )
+    masked = mask_text(block)
+    assert "eyJ.leak.sig" not in masked
+    assert "leakedkey123" not in masked
+    assert "[REDACTED:bearer-token]" in masked
+    assert "[REDACTED:function-key]" in masked
+    assert "2d0db691-8e70-4335-a8a9-e127715fa678" in masked
+
+
+def test_masks_each_secret_class():
+    cases = {
+        "Authorization: Bearer abc.def.ghi": "Authorization: Bearer [REDACTED:bearer-token]",
+        "Authorization: Basic dXNlcjpwYXNz": "Authorization: Basic [REDACTED:basic-auth]",
+        "Authorization: abc123def456ghi": "Authorization: [REDACTED:authorization]",
+        "GET /api/hello?code=secretkey123": "GET /api/hello?code=[REDACTED:function-key]",
+        "x-functions-key: secretkey123": "x-functions-key: [REDACTED:function-key]",
+        "AccountKey=Zm9vYmFyMTIz;EndpointSuffix=x": (
+            "AccountKey=[REDACTED:storage-key];EndpointSuffix=x"
+        ),
+        "SharedAccessKey=abc123;Entity=q": "SharedAccessKey=[REDACTED:shared-access-key];Entity=q",
+        "https://x?sig=abc%2Fdef&se=2026": "https://x?sig=[REDACTED:sas]&se=2026",
+        "SharedAccessSignature=sv=2021&sig=x": "SharedAccessSignature=[REDACTED:sas]",
+    }
+    for raw, expected in cases.items():
+        assert mask_text(raw) == expected, raw
+
+
+def test_shared_access_key_name_is_not_masked():
+    text = "Endpoint=sb://ns/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc"
+    masked = mask_text(text)
+    assert "SharedAccessKeyName=RootManageSharedAccessKey" in masked
+    assert "SharedAccessKey=[REDACTED:shared-access-key]" in masked
+
+
+def test_masking_is_idempotent():
+    text = SUCCESS_LOG.read_text() + WORKER_FAIL_LOG.read_text()
+    once = mask_text(text)
+    assert mask_text(once) == once
+    assert once != text
+
+
+def test_masking_preserves_extraction_tokens():
+    text = (
+        "Executing 'Functions.hello' (Reason='x', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)\n"
+        "Executed 'Functions.hello' (Succeeded, Id=6a8f3658, Duration=54ms)\n"
+        '  "status": "200",'
+    )
+    masked = mask_text(text)
+    assert masked == text
+
+
+def test_mask_record_rewrites_message_and_content():
+    record = LogRecord(
+        message="[ts] Authorization: Bearer leak",
+        timestamp=None,
+        fields={"content": "Authorization: Bearer leak", "ts": "ts"},
+    )
+    masked = mask_records([record])[0]
+    assert "leak" not in masked.message
+    assert "leak" not in masked.fields["content"]
+    assert masked.fields["ts"] == "ts"
+
+
+def _run(argv, stdin_text=""):
+    stdout = io.StringIO()
+    code = cli.main(
+        argv,
+        stdin=io.StringIO(stdin_text),
+        stdout=stdout,
+        stderr=io.StringIO(),
+        opener=lambda url: None,
+    )
+    return code, stdout.getvalue()
+
+
+def test_cli_parse_masks_secrets_by_default():
+    code, out = _run(["parse", str(SUCCESS_LOG)])
+    assert code == 0
+    dumped = json.dumps(json.loads(out))
+    assert "[REDACTED:bearer-token]" in dumped
+    assert "[REDACTED:function-key]" in dumped
+    assert "Bearer eyJ" not in dumped
+
+
+def test_cli_no_mask_preserves_raw_secrets():
+    code, out = _run(["parse", str(SUCCESS_LOG), "--no-mask"])
+    assert code == 0
+    dumped = json.dumps(json.loads(out))
+    assert "[REDACTED:" not in dumped
+    assert "Bearer eyJ" in dumped
+
+
+def test_cli_record_masks_secrets_by_default():
+    code, out = _run(["record", "-o", "-"], stdin_text=SUCCESS_LOG.read_text())
+    assert code == 0
+    dumped = json.dumps(json.loads(out))
+    assert "[REDACTED:bearer-token]" in dumped
+    assert "Bearer eyJ" not in dumped
+
+
+def test_cli_record_no_mask_preserves_raw_secrets():
+    code, out = _run(["record", "-o", "-", "--no-mask"], stdin_text=SUCCESS_LOG.read_text())
+    assert code == 0
+    dumped = json.dumps(json.loads(out))
+    assert "[REDACTED:" not in dumped
+    assert "Bearer eyJ" in dumped

--- a/tests/test_parser_success.py
+++ b/tests/test_parser_success.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from jsonschema import Draft202012Validator
 
 from funcviz.models import LogRecord
-from funcviz.parser import from_log_text, parse_trace
+from funcviz.parser import from_log_text, mask_records, parse_trace
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
@@ -31,7 +31,7 @@ FROZEN_EVENTS = [
 
 def _parsed() -> dict[str, object]:
     text = (ROOT / "samples" / "success.log").read_text()
-    return parse_trace(from_log_text(text), trace_id="success-001").to_dict()
+    return parse_trace(mask_records(from_log_text(text)), trace_id="success-001").to_dict()
 
 
 def test_success_log_validates_against_schema():
@@ -74,7 +74,7 @@ def test_multiline_http_block_is_folded_into_one_event():
 def test_bare_message_records_parse_without_from_log_text():
     text = (ROOT / "samples" / "success.log").read_text()
     bare = [LogRecord(message=line) for line in text.splitlines()]
-    assert parse_trace(bare, trace_id="success-001").to_dict() == _parsed()
+    assert parse_trace(mask_records(bare), trace_id="success-001").to_dict() == _parsed()
 
 
 def test_structured_timestamp_is_honored_over_message_prefix():

--- a/tests/test_parser_worker_fail.py
+++ b/tests/test_parser_worker_fail.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from jsonschema import Draft202012Validator
 
-from funcviz.parser import from_log_text, parse_trace
+from funcviz.parser import from_log_text, mask_records, parse_trace
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
@@ -33,7 +33,7 @@ RETRY_LOOP_MARKERS = ["Starting Host", "0 functions found"]
 
 def _parsed() -> dict[str, object]:
     text = (ROOT / "samples" / "worker-fail.log").read_text()
-    return parse_trace(from_log_text(text), trace_id="worker-fail-001").to_dict()
+    return parse_trace(mask_records(from_log_text(text)), trace_id="worker-fail-001").to_dict()
 
 
 def test_failure_log_validates_against_schema():

--- a/traces/success.json
+++ b/traces/success.json
@@ -48,7 +48,7 @@
       "event": "HttpRequestReceived",
       "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
       "confidence": "inferred",
-      "raw": "[2026-09-05T00:45:16.955Z] Executing HTTP request: {\n[2026-09-05T00:45:16.955Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:16.955Z]   \"method\": \"GET\",\n[2026-09-05T00:45:16.955Z]   \"userAgent\": \"curl/8.7.1\",\n[2026-09-05T00:45:16.955Z]   \"uri\": \"/api/hello\"\n[2026-09-05T00:45:16.955Z] }"
+      "raw": "[2026-09-05T00:45:16.955Z] Executing HTTP request: {\n[2026-09-05T00:45:16.955Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:16.955Z]   \"method\": \"GET\",\n[2026-09-05T00:45:16.955Z]   \"userAgent\": \"curl/8.7.1\",\n[2026-09-05T00:45:16.955Z]   \"Authorization\": \"Bearer [REDACTED:bearer-token]\",\n[2026-09-05T00:45:16.955Z]   \"uri\": \"/api/hello?code=[REDACTED:function-key]\"\n[2026-09-05T00:45:16.955Z] }"
     },
     {
       "id": "e1",

--- a/traces/worker-fail.json
+++ b/traces/worker-fail.json
@@ -46,7 +46,7 @@
       "lane": "host",
       "event": "HostBuildStarted",
       "confidence": "observed",
-      "raw": "[2026-09-05T00:45:57.407Z] Building host: version spec: , startup suppressed: 'False', configuration suppressed: 'False', startup operation id: 'bf56153b-c386-4502-b9d3-3ffb7acace98'"
+      "raw": "[2026-09-05T00:45:57.407Z] Building host: version spec: , startup suppressed: 'False', configuration suppressed: 'False', startup operation id: 'bf56153b-c386-4502-b9d3-3ffb7acace98', AzureWebJobsStorage=DefaultEndpointsProtocol=https;AccountName=funcstore01;AccountKey=[REDACTED:storage-key];EndpointSuffix=core.windows.net"
     },
     {
       "id": "e1",


### PR DESCRIPTION
## Summary
- Redact `Authorization` headers, function keys (`?code=`/`x-functions-key`), and connection-string credentials (`AccountKey`, `SharedAccessKey`, `sig`, `Password`, `ClientSecret`, `AccessKey`) before the trace is built. Masking is **on by default**; `funcviz parse`/`record` accept `--no-mask` to opt out.
- Each secret is replaced with a visible typed marker (e.g. `[REDACTED:bearer-token]`), never silently dropped (PRD §16).
- Generic (non-Bearer/Basic) Authorization values are redacted **whole** so the credential tail cannot leak. The value classes require a non-whitespace first char so the separator's `\s*` cannot backtrack past an already Bearer/Basic-masked value (which previously dropped the `: "` separator and overrode the typed marker). All redactions are idempotent.
- `re` stays isolated to `regexes.py` (PRD R1); removed the last `re` import from `cli.py`.

## Verification
- 88/88 tests pass; ruff clean.
- Goldens regenerated: `success.json` has `bearer-token` + `function-key`, `worker-fail.json` has `storage-key`; no plaintext leak.
- Viewer headless-rendered with both markers visible and 0 console errors.
- Oracle review: 93/100, no blocking issues.

Closes #11