### PR TITLE
build: package v0.1.0 for PyPI with clean-machine acceptance (#12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e ".[dev]"
+      - run: ruff check src/ tests/
+      - run: pytest -q
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip build twine
+      - run: python -m build
+      - run: python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip build twine
+      - run: python -m build
+      - run: python -m twine check dist/*
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to `funcviz` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-09-05
+
+First public release.
+
+### Added
+
+- Pure-Python (stdlib-only, zero runtime dependencies) parser that turns Azure
+  Functions verbose runtime logs into a versioned trace JSON.
+- Three-lane execution timeline (Client / Functions Host / Python Worker) plus an
+  application source panel, rendered by a self-contained static HTML viewer.
+- One success trace and one worker-startup-failure trace, each event carrying a
+  `confidence` field (`observed` vs `inferred`) and its original log line.
+- CLI: `funcviz parse`, `funcviz view`, and `funcviz record`.
+- Secret masking on by default (`--no-mask` to opt out): Authorization headers,
+  function keys, and connection-string credentials are replaced with visible
+  typed markers, never silently dropped.
+- Confidence boundary banner in the viewer distinguishing observed from inferred
+  activity.
+- PyPI packaging via hatchling; the static viewer asset ships inside the wheel.
+
+[0.1.0]: https://github.com/yeongseon/azure-functions-runtime-visualizer/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ engineers, SME presentations, and onboarding need.
 ## How it works
 
 ```bash
+# 0. Install
+pip install funcviz
+
 # 1. Capture (you run this against your own Function App)
 func start --verbose > run.log
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,43 @@
+# Releasing funcviz
+
+This project publishes to PyPI with a hatchling build and GitHub Actions
+Trusted Publishing (OIDC) — no long-lived API token is stored in the repo.
+
+## One-time setup
+
+On PyPI, add a **pending publisher** for the `funcviz` project pointing at this
+repository, workflow file `release.yml`, and environment `pypi`. This authorizes
+the workflow to publish without a token.
+
+## Cutting a release
+
+1. Bump `version` in `pyproject.toml` and add a matching section to
+   `CHANGELOG.md`.
+2. Merge to `main`.
+3. Tag and push:
+
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+4. Create a GitHub Release from the tag. Publishing the release triggers
+   `.github/workflows/release.yml`, which builds the sdist + wheel and uploads
+   them to PyPI via Trusted Publishing.
+
+## Verifying a build locally before tagging
+
+```bash
+python -m build
+python -m twine check dist/*
+
+# clean-machine simulation (no PYTHONPATH, no editable install)
+python -m venv /tmp/fvclean
+/tmp/fvclean/bin/pip install dist/funcviz-*.whl
+/tmp/fvclean/bin/funcviz --help
+cp traces/success.json /tmp/fvclean/success.json
+cd /tmp/fvclean && ./bin/funcviz view success.json --html-out out.html
+```
+
+Assert that both artifacts contain `funcviz/viewer/index.html`, `twine check`
+passes, and `funcviz view` renders a trace against a user-supplied file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "funcviz"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "Turn Azure Functions verbose runtime logs into an interactive execution timeline."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -37,9 +37,20 @@ dev = ["pytest>=8", "ruff>=0.6", "jsonschema>=4"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/funcviz"]
 
-# Ship the static viewer asset(s) inside the wheel.
-[tool.hatch.build.targets.wheel.force-include]
-"src/funcviz/viewer" = "funcviz/viewer"
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/funcviz",
+    "tests",
+    "schemas",
+    "traces",
+    "samples",
+    "docs",
+    "examples",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "pyproject.toml",
+]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- Set release version to **0.1.0** and removed the redundant wheel `force-include` that duplicated `funcviz/viewer/index.html` and broke `python -m build`. The viewer still ships via package inclusion (`packages=["src/funcviz"]`), verified present in both wheel and sdist.
- Added an explicit `[tool.hatch.build.targets.sdist]` include (package, tests, schemas, traces, samples, docs, examples, README, LICENSE, CHANGELOG, pyproject).
- Added `CHANGELOG.md`, a release runbook (`docs/release.md`), and a `pip install funcviz` note in the README.
- Added CI (`ruff` + `pytest` on py3.10–3.12, plus `build` + `twine check`) and a Trusted-Publishing release workflow (OIDC, no stored token) triggered on GitHub Release.

## Verification (clean-machine acceptance, PRD §17)
- `python -m build` produces wheel + sdist; `twine check dist/*` PASSED both.
- Viewer asset present in wheel (`funcviz/viewer/index.html`) and sdist (`src/funcviz/viewer/index.html`).
- Fresh `venv` **outside the repo**, `pip install dist/*.whl` (no `PYTHONPATH`, not editable): `pip check` clean, `funcviz --help` works, `funcviz view <trace>` renders with masking marker, `pip show -f` lists the viewer asset.
- 88/88 tests pass; ruff clean; workflow YAML valid.
- Oracle review: **94/100**, blocker-free.

## Not done here (requires credentials)
The live PyPI upload is intentionally not performed — it is automated via the release workflow and requires a one-time PyPI Trusted Publisher (pending publisher) setup, documented in `docs/release.md`.

Closes #12