### PR TITLE
feat(parser): emit inferred application-lane window events (#25)

### DIFF
--- a/src/funcviz/parser/core.py
+++ b/src/funcviz/parser/core.py
@@ -20,7 +20,13 @@ from ..models import (
     TraceInput,
 )
 from ..models import LogRecord as LogRecord
-from .derive import build_failures, build_intervals, build_lanes, finalize_events
+from .derive import (
+    build_failures,
+    build_intervals,
+    build_lanes,
+    finalize_events,
+    synthesize_application_events,
+)
 from .events import extract_events
 from .records import fold_http_blocks, record_content
 from .records import from_log_text as _from_log_text
@@ -48,7 +54,7 @@ def parse_trace(
     outcome: Outcome = Outcome.SUCCESS,
 ) -> Trace:
     folded = fold_http_blocks(log_records)
-    raw_events = extract_events(folded)
+    raw_events = synthesize_application_events(extract_events(folded))
     finalized = finalize_events(raw_events)
     intervals = build_intervals(finalized, raw_events)
     lanes = build_lanes(finalized)

--- a/src/funcviz/parser/derive.py
+++ b/src/funcviz/parser/derive.py
@@ -37,6 +37,72 @@ _FAIL_APPLICATION_REASON = (
 )
 
 
+_APPLICATION_INTERVAL_LABEL = "Application (inferred window)"
+
+
+def synthesize_application_events(
+    raw_events: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Insert the two inferred ``application``-lane window events (PRD FR-4).
+
+    The application lane has no dedicated log line (docs/event-coverage.md): user
+    code entry/exit is inferred from the surrounding observed events. When a
+    success trace pairs a ``WorkerReceivedInvocation`` with a matching later
+    ``InvocationCompleted`` (same ``invocationId``), we synthesize an
+    ``ApplicationFunctionStarted`` immediately after the worker received the
+    invocation and an ``ApplicationFunctionCompleted`` immediately before the host
+    reported completion, so the lane owns the two markers FR-4 requires. These are
+    inferences, not log records, so they carry ``confidence = INFERRED`` and
+    ``raw = None``. Failure traces (indexing never reached the function body)
+    synthesize nothing and leave the application lane empty.
+    """
+    names = {str(e["event"]) for e in raw_events}
+    if names & {"ApplicationFunctionStarted", "ApplicationFunctionCompleted"}:
+        return list(raw_events)
+
+    worker_idx = next(
+        (i for i, e in enumerate(raw_events) if e["event"] == "WorkerReceivedInvocation"), None
+    )
+    completed_idx = next(
+        (i for i, e in enumerate(raw_events) if e["event"] == "InvocationCompleted"), None
+    )
+    if worker_idx is None or completed_idx is None or worker_idx >= completed_idx:
+        return list(raw_events)
+
+    worker = raw_events[worker_idx]
+    completed = raw_events[completed_idx]
+    if worker.get("invocationId") != completed.get("invocationId"):
+        return list(raw_events)
+
+    invocation_id = worker.get("invocationId")
+
+    started = {
+        "event": "ApplicationFunctionStarted",
+        "lane": Lane.APPLICATION,
+        "confidence": Confidence.INFERRED,
+        "timestamp": worker["timestamp"],
+        "raw": None,
+        "invocationId": invocation_id,
+    }
+    finished = {
+        "event": "ApplicationFunctionCompleted",
+        "lane": Lane.APPLICATION,
+        "confidence": Confidence.INFERRED,
+        "timestamp": completed["timestamp"],
+        "raw": None,
+        "invocationId": invocation_id,
+    }
+
+    result: list[dict[str, object]] = []
+    for event in raw_events:
+        if event is completed:
+            result.append(finished)
+        result.append(event)
+        if event is worker:
+            result.append(started)
+    return result
+
+
 def _to_dt(ts: str) -> datetime:
     return datetime.fromisoformat(ts.replace("Z", "+00:00"))
 
@@ -128,6 +194,28 @@ def build_intervals(events: list[Event], raw_events: list[dict[str, object]]) ->
                     raw=f'"duration": "{http_duration}"',
                 )
             )
+
+    app_started = by_name.get("ApplicationFunctionStarted")
+    app_completed = by_name.get("ApplicationFunctionCompleted")
+    if (
+        app_started is not None
+        and app_completed is not None
+        and app_started.timestamp
+        and app_completed.timestamp
+    ):
+        intervals.append(
+            Interval(
+                id="i4",
+                label=_APPLICATION_INTERVAL_LABEL,
+                lane=Lane.APPLICATION,
+                kind="application",
+                start_event=app_started.id,
+                end_event=app_completed.id,
+                duration_ms=_elapsed_ms(app_completed.timestamp, app_started.timestamp),
+                source=IntervalSource.INFERRED,
+                confidence=Confidence.INFERRED,
+            )
+        )
     return intervals
 
 
@@ -151,8 +239,7 @@ def build_lanes(events: list[Event]) -> Lanes:
         )
 
     names = {e.event for e in events}
-    completed = next((e for e in events if e.event == "InvocationCompleted"), None)
-    application_reached = completed is not None
+    application_reached = "ApplicationFunctionStarted" in names
 
     client_reached = bool(names & {"HttpRequestReceived", "HttpResponseReturned"})
     host_reached = bool(names & {"InvocationStarted", "InvocationCompleted"})

--- a/tests/test_parser_application_synthesis.py
+++ b/tests/test_parser_application_synthesis.py
@@ -1,0 +1,82 @@
+"""Edge-case contracts for the inferred application-window synthesis (issue #25).
+
+``synthesize_application_events`` turns an observed Host<->Worker boundary into
+the two inferred application-lane markers. These tests pin the guard behavior
+that the golden happy-path traces cannot exercise: the pair is emitted only when
+a worker receipt is followed by a matching completion, and never otherwise.
+"""
+
+from __future__ import annotations
+
+from funcviz.models import Confidence, Lane
+from funcviz.parser.derive import synthesize_application_events
+
+_INV = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
+
+
+def _worker(invocation: str = _INV, ts: str = "2024-01-01T00:00:00.100Z") -> dict[str, object]:
+    return {
+        "event": "WorkerReceivedInvocation",
+        "lane": Lane.PYTHON_WORKER,
+        "confidence": Confidence.OBSERVED,
+        "timestamp": ts,
+        "raw": "received",
+        "invocationId": invocation,
+        "workerRequestId": "w-1",
+    }
+
+
+def _completed(invocation: str = _INV, ts: str = "2024-01-01T00:00:00.150Z") -> dict[str, object]:
+    return {
+        "event": "InvocationCompleted",
+        "lane": Lane.HOST,
+        "confidence": Confidence.OBSERVED,
+        "timestamp": ts,
+        "raw": "executed",
+        "invocationId": invocation,
+    }
+
+
+def _names(events: list[dict[str, object]]) -> list[str]:
+    return [str(e["event"]) for e in events]
+
+
+def test_pair_is_inserted_between_the_boundary_events():
+    out = synthesize_application_events([_worker(), _completed()])
+    assert _names(out) == [
+        "WorkerReceivedInvocation",
+        "ApplicationFunctionStarted",
+        "ApplicationFunctionCompleted",
+        "InvocationCompleted",
+    ]
+    started, finished = out[1], out[2]
+    for event in (started, finished):
+        assert event["lane"] is Lane.APPLICATION
+        assert event["confidence"] is Confidence.INFERRED
+        assert event["raw"] is None
+        assert event["invocationId"] == _INV
+        assert "workerRequestId" not in event
+
+
+def test_no_synthesis_without_a_worker_receipt():
+    assert _names(synthesize_application_events([_completed()])) == ["InvocationCompleted"]
+
+
+def test_no_synthesis_without_a_completion():
+    assert _names(synthesize_application_events([_worker()])) == ["WorkerReceivedInvocation"]
+
+
+def test_no_synthesis_on_invocation_id_mismatch():
+    events = [_worker(invocation="aaaa"), _completed(invocation="bbbb")]
+    assert _names(synthesize_application_events(events)) == _names(events)
+
+
+def test_no_synthesis_when_completion_precedes_worker_receipt():
+    events = [_completed(ts="2024-01-01T00:00:00.100Z"), _worker(ts="2024-01-01T00:00:00.200Z")]
+    assert _names(synthesize_application_events(events)) == _names(events)
+
+
+def test_synthesis_is_idempotent():
+    once = synthesize_application_events([_worker(), _completed()])
+    twice = synthesize_application_events(once)
+    assert _names(twice) == _names(once)

--- a/tests/test_parser_contracts.py
+++ b/tests/test_parser_contracts.py
@@ -65,7 +65,12 @@ def test_inferred_lanes_carry_a_reason_and_no_lane_reports_failure():
 
 def test_event_confidence_is_classified_by_deliberate_rule():
     observed = {"InvocationStarted", "WorkerReceivedInvocation", "InvocationCompleted"}
-    inferred = {"HttpRequestReceived", "HttpResponseReturned"}
+    inferred = {
+        "HttpRequestReceived",
+        "HttpResponseReturned",
+        "ApplicationFunctionStarted",
+        "ApplicationFunctionCompleted",
+    }
     for event in _events():
         name = event["event"]
         if name in observed:
@@ -100,6 +105,34 @@ def test_three_ids_stay_distinct_and_attach_to_the_right_events():
         assert event["invocationId"] == INVOCATION_ID
         assert "httpRequestId" not in event
         assert "workerRequestId" not in event
+
+
+def test_application_window_is_a_pair_of_inferred_events_between_worker_and_completion():
+    events = _events()
+    by_name = {event["event"]: event for event in events}
+    started = by_name["ApplicationFunctionStarted"]
+    finished = by_name["ApplicationFunctionCompleted"]
+
+    for event in (started, finished):
+        assert event["lane"] == "application"
+        assert event["confidence"] == "inferred"
+        assert event["raw"] is None
+        assert event["invocationId"] == INVOCATION_ID
+
+    seq = {event["event"]: event["sequence"] for event in events}
+    assert seq["WorkerReceivedInvocation"] < seq["ApplicationFunctionStarted"]
+    assert seq["ApplicationFunctionStarted"] < seq["ApplicationFunctionCompleted"]
+    assert seq["ApplicationFunctionCompleted"] < seq["InvocationCompleted"]
+
+
+def test_application_lane_owns_the_inferred_window_interval():
+    intervals = _trace()["intervals"]
+    assert isinstance(intervals, list)
+    app_intervals = [i for i in intervals if i["lane"] == "application"]
+    assert len(app_intervals) == 1
+    interval = app_intervals[0]
+    assert interval["source"] == "inferred"
+    assert interval["confidence"] == "inferred"
 
 
 def test_lifecycle_ordering_invariants_hold():

--- a/tests/test_parser_success.py
+++ b/tests/test_parser_success.py
@@ -24,6 +24,8 @@ FROZEN_EVENTS = [
     "HttpRequestReceived",
     "InvocationStarted",
     "WorkerReceivedInvocation",
+    "ApplicationFunctionStarted",
+    "ApplicationFunctionCompleted",
     "InvocationCompleted",
     "HttpResponseReturned",
 ]
@@ -41,7 +43,7 @@ def test_success_log_validates_against_schema():
 def test_event_order_matches_log_order():
     doc = _parsed()
     assert [e["event"] for e in doc["events"]] == FROZEN_EVENTS
-    assert [e["elapsedMs"] for e in doc["events"]] == [0, 251, 272, 285, 294]
+    assert [e["elapsedMs"] for e in doc["events"]] == [0, 251, 272, 272, 285, 285, 294]
 
 
 def test_intervals_preserve_duration_provenance():
@@ -50,6 +52,7 @@ def test_intervals_preserve_duration_provenance():
         ("i1", "log-delta", 34),
         ("i2", "host-reported", 54),
         ("i3", "http-reported", 294),
+        ("i4", "inferred", 13),
     ]
 
 

--- a/tests/test_parser_worker_fail.py
+++ b/tests/test_parser_worker_fail.py
@@ -58,6 +58,8 @@ def test_no_http_or_invocation_events_leak_in():
         "InvocationStarted",
         "InvocationCompleted",
         "WorkerReceivedInvocation",
+        "ApplicationFunctionStarted",
+        "ApplicationFunctionCompleted",
     }
     assert not (names & forbidden)
 

--- a/traces/success.json
+++ b/traces/success.json
@@ -76,6 +76,28 @@
     {
       "id": "e3",
       "sequence": 3,
+      "timestamp": "2026-09-05T00:45:17.227Z",
+      "elapsedMs": 272,
+      "lane": "application",
+      "event": "ApplicationFunctionStarted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "inferred",
+      "raw": null
+    },
+    {
+      "id": "e4",
+      "sequence": 4,
+      "timestamp": "2026-09-05T00:45:17.240Z",
+      "elapsedMs": 285,
+      "lane": "application",
+      "event": "ApplicationFunctionCompleted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "inferred",
+      "raw": null
+    },
+    {
+      "id": "e5",
+      "sequence": 5,
       "timestamp": "2026-09-05T00:45:17.240Z",
       "elapsedMs": 285,
       "lane": "host",
@@ -85,8 +107,8 @@
       "raw": "[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Succeeded, Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b, Duration=54ms)"
     },
     {
-      "id": "e4",
-      "sequence": 4,
+      "id": "e6",
+      "sequence": 6,
       "timestamp": "2026-09-05T00:45:17.249Z",
       "elapsedMs": 294,
       "lane": "client",
@@ -103,7 +125,7 @@
       "lane": "host",
       "kind": "invocation",
       "startEvent": "e1",
-      "endEvent": "e3",
+      "endEvent": "e5",
       "durationMs": 34,
       "source": "log-delta",
       "confidence": "observed"
@@ -114,7 +136,7 @@
       "lane": "host",
       "kind": "invocation",
       "startEvent": "e1",
-      "endEvent": "e3",
+      "endEvent": "e5",
       "durationMs": 54,
       "source": "host-reported",
       "confidence": "observed",
@@ -126,11 +148,22 @@
       "lane": "client",
       "kind": "http",
       "startEvent": "e0",
-      "endEvent": "e4",
+      "endEvent": "e6",
       "durationMs": 294,
       "source": "http-reported",
       "confidence": "inferred",
       "raw": "\"duration\": \"294\""
+    },
+    {
+      "id": "i4",
+      "label": "Application (inferred window)",
+      "lane": "application",
+      "kind": "application",
+      "startEvent": "e3",
+      "endEvent": "e4",
+      "durationMs": 13,
+      "source": "inferred",
+      "confidence": "inferred"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Closes #25. The frozen Phase-0 event list reserves two **inferred** application-lane events (`ApplicationFunctionStarted`, `ApplicationFunctionCompleted`) that were never emitted, so the application lane reported `reached` while owning **zero** renderable events — an FR-4 gap and a PRD §10 overclaim.

`derive.py` now synthesizes the pair from the observed Host↔Worker boundary, **before** id/sequence/elapsed finalization:
- `ApplicationFunctionStarted` immediately after `WorkerReceivedInvocation`
- `ApplicationFunctionCompleted` immediately before `InvocationCompleted`
- both `inferred`, `raw: null`, tagged with the shared `invocationId`
- guarded on matching `invocationId` **and** correct ordering (worker before completion)
- adds an inferred `application` interval (`i4`)
- lane reachability now driven off the synthesized start event
- failure traces synthesize nothing (application stays `not-reached`)

Parser purity preserved — no new `import re` (PRD R1).

## Verification
- 96 tests pass (6 new synthesis edge-case tests + updated contracts/golden), `ruff` clean, `re`-isolation test passes.
- Regenerated `traces/success.json` (now 7 events + `i4`); `traces/worker-fail.json` unchanged.
- Headless viewer check: 0 console errors; replay rail now steps through all 7 events. Application events remain out of the 3 swimlanes by design (the application lane lives in the source panel — that is #26's scope).

## Review
Oracle design + implementation review: **92/100, no blocking issues**. Recommended hardening applied (ordering guard, dropped redundant `workerRequestId`, edge-case tests).