### PR TITLE
feat(cli): embed executed source via parse --source for viewer panel (#26)

### DIFF
--- a/src/funcviz/cli.py
+++ b/src/funcviz/cli.py
@@ -25,6 +25,7 @@ from urllib.request import pathname2url
 
 from funcviz.models import LogRecord
 from funcviz.parser import from_log_text, mask_records, parse_trace
+from funcviz.source import enrich_trace_from_source
 
 Opener = Callable[[str], object]
 
@@ -48,6 +49,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output trace JSON path, or '-' for stdout (default: stdout).",
     )
     parse_cmd.add_argument("--trace-id", help="Override the generated traceId.")
+    parse_cmd.add_argument(
+        "--source",
+        help="Executed application source file to embed for the viewer's source panel.",
+    )
     parse_cmd.add_argument(
         "--no-mask",
         action="store_true",
@@ -133,6 +138,12 @@ def cmd_parse(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: Op
     text = _read_text_arg(args.input, stdin)
     trace_id = args.trace_id or _default_trace_id(args.input, text)
     trace = parse_trace(_records(text, no_mask=args.no_mask), trace_id=trace_id)
+    if args.source:
+        trace = enrich_trace_from_source(
+            trace,
+            Path(args.source),
+            warn=lambda message: print(message, file=stderr),
+        )
     _write_json(trace.to_dict(), args.output, stdout)
     return 0
 

--- a/src/funcviz/source.py
+++ b/src/funcviz/source.py
@@ -1,0 +1,120 @@
+"""Post-parse source enrichment (PRD FR-6, AC6).
+
+This module lives *outside* :mod:`funcviz.parser` on purpose. The parser is a
+pure log reader with no filesystem access (see ``parser/core.py``); embedding
+the executed application's source text requires reading a file, so it is done
+here as a separate transformation applied *above* the parser.
+
+The public entry point :func:`enrich_trace_from_source` reads the given source
+file, embeds its text into ``trace.application.sourceText``, and — for Python
+sources whose defining function can be unambiguously located — records the
+``definitionLineRange`` (1-based, decorator-inclusive) used by the viewer's
+source panel to highlight the executed function.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+
+from funcviz.models import Application, Trace
+
+Warn = Callable[[str], None]
+
+
+def _noop(_message: str) -> None:  # pragma: no cover - trivial default
+    pass
+
+
+def enrich_trace_from_source(
+    trace: Trace,
+    source_path: Path,
+    *,
+    warn: Warn | None = None,
+) -> Trace:
+    """Return a copy of ``trace`` enriched with the executed source file.
+
+    The source text is read from ``source_path`` and always embedded when the
+    file is readable. Reading failures (missing/unreadable file) propagate as
+    :class:`OSError` because the caller explicitly requested embedding via
+    ``--source``; the CLI turns that into a hard error.
+
+    Locating the defining function is best-effort: a syntax error, non-Python
+    source, or an ambiguous/absent function match emits a warning and omits
+    ``definitionLineRange`` while still embedding ``sourceText``.
+    """
+    warn = warn or _noop
+    source_text = source_path.read_text(encoding="utf-8")
+
+    application = trace.application or Application(function_name="")
+    if application.source_file is not None and application.source_file != source_path.name:
+        warn(
+            f"funcviz: --source basename {source_path.name!r} differs from "
+            f"log-reported sourceFile {application.source_file!r}; using --source."
+        )
+    source_file = source_path.name
+
+    line_range = _definition_line_range(
+        source_text,
+        source_path,
+        application.function_name,
+        warn=warn,
+    )
+
+    enriched = replace(
+        application,
+        source_file=source_file,
+        source_text=source_text,
+        definition_line_range=line_range,
+    )
+    return replace(trace, application=enriched)
+
+
+def _definition_line_range(
+    source_text: str,
+    source_path: Path,
+    function_name: str,
+    *,
+    warn: Warn,
+) -> tuple[int, int] | None:
+    if source_path.suffix != ".py":
+        warn(
+            f"funcviz: {source_path.name} is not a Python source file; "
+            "omitting definitionLineRange."
+        )
+        return None
+    if not function_name:
+        warn("funcviz: no application function name available; omitting definitionLineRange.")
+        return None
+
+    try:
+        tree = ast.parse(source_text)
+    except SyntaxError as exc:
+        warn(f"funcviz: could not parse {source_path.name} ({exc}); omitting definitionLineRange.")
+        return None
+
+    matches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
+    ]
+    if len(matches) != 1:
+        detail = "no match" if not matches else f"{len(matches)} matches"
+        warn(
+            f"funcviz: function {function_name!r} has {detail} in {source_path.name}; "
+            "omitting definitionLineRange."
+        )
+        return None
+
+    node = matches[0]
+    start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+    end = node.end_lineno
+    if end is None or start < 1 or start > end:
+        warn(
+            f"funcviz: invalid line range for {function_name!r} in {source_path.name}; "
+            "omitting definitionLineRange."
+        )
+        return None
+    return (start, end)

--- a/tests/test_source_enrichment.py
+++ b/tests/test_source_enrichment.py
@@ -1,0 +1,111 @@
+"""Source enrichment tests for ``funcviz parse --source`` (issue #26, AC6)."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from funcviz import cli
+
+ROOT = Path(__file__).resolve().parent.parent
+SUCCESS_LOG = ROOT / "samples" / "success.log"
+EXAMPLE_SOURCE = ROOT / "examples" / "python-http-trigger" / "function_app.py"
+
+
+def _run(argv, stdin_text=""):
+    stdin = io.StringIO(stdin_text)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = cli.main(argv, stdin=stdin, stdout=stdout, stderr=stderr, opener=lambda url: None)
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_parse_source_embeds_text_and_range():
+    code, stdout, stderr = _run(["parse", str(SUCCESS_LOG), "--source", str(EXAMPLE_SOURCE)])
+    assert code == 0
+    assert stderr == ""
+    application = json.loads(stdout)["application"]
+    assert application["sourceText"] == EXAMPLE_SOURCE.read_text()
+    assert application["definitionLineRange"] == [6, 9]
+    assert application["sourceFile"] == "function_app.py"
+
+
+def test_parse_without_source_omits_text():
+    code, stdout, _ = _run(["parse", str(SUCCESS_LOG)])
+    assert code == 0
+    application = json.loads(stdout)["application"]
+    assert "sourceText" not in application
+
+
+def test_parse_missing_source_is_hard_error(tmp_path):
+    missing = tmp_path / "nope.py"
+    code, _, stderr = _run(["parse", str(SUCCESS_LOG), "--source", str(missing)])
+    assert code == 1
+    assert "funcviz:" in stderr
+
+
+def test_parse_source_function_not_found_warns_and_omits_range(tmp_path):
+    other = tmp_path / "other.py"
+    other.write_text("def unrelated():\n    return 1\n")
+    code, stdout, stderr = _run(["parse", str(SUCCESS_LOG), "--source", str(other)])
+    assert code == 0
+    application = json.loads(stdout)["application"]
+    assert application["sourceText"] == other.read_text()
+    assert "definitionLineRange" not in application
+    assert "no match" in stderr
+
+
+def test_parse_source_syntax_error_warns_and_omits_range(tmp_path):
+    broken = tmp_path / "broken.py"
+    broken.write_text("def hello(:\n")
+    code, stdout, stderr = _run(["parse", str(SUCCESS_LOG), "--source", str(broken)])
+    assert code == 0
+    application = json.loads(stdout)["application"]
+    assert application["sourceText"] == broken.read_text()
+    assert "definitionLineRange" not in application
+    assert "could not parse" in stderr
+
+
+def test_parse_non_python_source_embeds_text_only(tmp_path):
+    txt = tmp_path / "handler.txt"
+    txt.write_text("hello source\n")
+    code, stdout, stderr = _run(["parse", str(SUCCESS_LOG), "--source", str(txt)])
+    assert code == 0
+    application = json.loads(stdout)["application"]
+    assert application["sourceText"] == txt.read_text()
+    assert "definitionLineRange" not in application
+    assert "not a Python source file" in stderr
+
+
+def test_enriched_trace_renders_in_viewer(tmp_path):
+    trace_out = tmp_path / "trace.json"
+    _run(["parse", str(SUCCESS_LOG), "--source", str(EXAMPLE_SOURCE), "-o", str(trace_out)])
+    html_out = tmp_path / "viewer.html"
+    code, _, _ = _run(["view", str(trace_out), "--html-out", str(html_out)])
+    assert code == 0
+    html = html_out.read_text()
+    assert '"sourceText"' in html
+    assert '"definitionLineRange":[6,9]' in html
+
+
+def test_parse_source_basename_mismatch_uses_source_file(tmp_path):
+    renamed = tmp_path / "renamed.py"
+    renamed.write_text(EXAMPLE_SOURCE.read_text())
+    code, stdout, stderr = _run(["parse", str(SUCCESS_LOG), "--source", str(renamed)])
+    assert code == 0
+    application = json.loads(stdout)["application"]
+    assert application["sourceFile"] == "renamed.py"
+    assert application["definitionLineRange"] == [6, 9]
+    assert "differs from" in stderr
+
+
+def test_parse_source_duplicate_function_warns_and_omits_range(tmp_path):
+    dup = tmp_path / "dup.py"
+    dup.write_text("def hello():\n    return 1\n\n\ndef hello():\n    return 2\n")
+    code, stdout, stderr = _run(["parse", str(SUCCESS_LOG), "--source", str(dup)])
+    assert code == 0
+    application = json.loads(stdout)["application"]
+    assert application["sourceText"] == dup.read_text()
+    assert "definitionLineRange" not in application
+    assert "2 matches" in stderr


### PR DESCRIPTION
## Summary
- Adds `funcviz parse --source PATH` to embed the executed application's `sourceText` and `definitionLineRange`, so the viewer's source panel (AC6) works against real CLI output rather than only the hardcoded demo trace.
- Enrichment lives in a new `src/funcviz/source.py` module **above** the parser, keeping `parse_trace()` filesystem-free and the golden traces byte-for-byte unchanged (Option A).
- `definitionLineRange` is computed with `ast` (decorator-inclusive); missing/ambiguous function or non-Python source warns to stderr and omits the range while still embedding text. A missing `--source` file is a hard error.

## Testing
- 105 tests pass (+9 new in `tests/test_source_enrichment.py`), ruff clean, regex-isolation intact (source.py uses `ast`, not `re`).
- Golden traces unchanged; parser purity contract preserved.
- Headless viewer renders the source panel (9 lines, def-line range [6,9]) with zero console errors.

Closes #26.