### PR TITLE
feat(parser): render in-invocation failures with a host-lane stop anchor (#27)

### DIFF
--- a/samples/invocation-fail.log
+++ b/samples/invocation-fail.log
@@ -1,0 +1,338 @@
+'local.settings.json' found in root directory (/Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger).
+Resolving worker runtime to 'python'.
+Found Python version 3.12.14 (python3).
+Selected out-of-process host.
+
+
+                  %%%%%%
+                 %%%%%%
+            @   %%%%%%    @
+          @@   %%%%%%      @@
+       @@@    %%%%%%%%%%%    @@@
+     @@      %%%%%%%%%%        @@
+       @@         %%%%       @@
+         @@      %%%       @@
+           @@    %%      @@
+                %%
+                %
+
+
+Azure Functions Core Tools
+Core Tools Version:       4.6.0+ab90faafcab539d63cd3d0ce5faf1bca4395fccc (64-bit)
+Function Runtime Version: 4.1045.200.25556
+
+[2026-09-05T00:45:11.402Z] Building host: version spec: , startup suppressed: 'False', configuration suppressed: 'False', startup operation id: 'de8ee930-7b72-4550-a78a-2f7520c7fca2'
+[2026-09-05T00:45:11.480Z] Reading host configuration file '/Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/host.json'
+[2026-09-05T00:45:11.480Z] Host configuration file read:
+[2026-09-05T00:45:11.480Z] {
+[2026-09-05T00:45:11.480Z]   "version": "2.0",
+[2026-09-05T00:45:11.480Z]   "logging": {
+[2026-09-05T00:45:11.480Z]     "logLevel": {
+[2026-09-05T00:45:11.480Z]       "default": "Information",
+[2026-09-05T00:45:11.480Z]       "Microsoft.Azure.WebJobs.Script.Grpc": "Trace",
+[2026-09-05T00:45:11.480Z]       "Worker": "Trace",
+[2026-09-05T00:45:11.481Z]       "Host.Function.Console": "Trace"
+[2026-09-05T00:45:11.481Z]     }
+[2026-09-05T00:45:11.481Z]   },
+[2026-09-05T00:45:11.481Z]   "extensionBundle": {
+[2026-09-05T00:45:11.481Z]     "id": "Microsoft.Azure.Functions.ExtensionBundle",
+[2026-09-05T00:45:11.481Z]     "version": "[4.*, 5.0.0)"
+[2026-09-05T00:45:11.481Z]   }
+[2026-09-05T00:45:11.481Z] }
+[2026-09-05T00:45:11.494Z] Looking for extension bundle Microsoft.Azure.Functions.ExtensionBundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle
+[2026-09-05T00:45:11.495Z] Applying platform release channel configuration LATEST. Bundle version 4.37.1 will be used
+[2026-09-05T00:45:11.495Z] Found a matching extension bundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1
+[2026-09-05T00:45:11.518Z] Loading functions metadata
+[2026-09-05T00:45:11.519Z] Worker indexing is enabled
+[2026-09-05T00:45:11.520Z] Fetching metadata for workerRuntime: python
+[2026-09-05T00:45:11.520Z] Reading functions metadata (Worker)
+[2026-09-05T00:45:11.803Z]  INFO: Starting Azure Functions Python Worker.
+[2026-09-05T00:45:11.803Z]  INFO: Worker ID: f17a18d1-fb59-43c9-af61-a80e59f4ca50, Request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, Host Address: 127.0.0.1:56863
+[2026-09-05T00:45:12.112Z]  INFO: Successfully opened gRPC channel to 127.0.0.1:56863 
+[2026-09-05T00:45:12.112Z]  INFO: Detaching console logging.
+[2026-09-05T00:45:14.155Z] Switched to gRPC logging.
+[2026-09-05T00:45:14.166Z] Received WorkerInitRequest, python version 3.12.14 (main, Aug 12 2026, 13:57:54) [Clang 21.0.0 (clang-2100.1.1.101)], worker version 4.40.2, request ID e42785bf-7670-4de1-a81d-b05df7b2b32d. App Settings state: PYTHON_THREADPOOL_THREAD_COUNT: 1000 | PYTHON_ENABLE_DEBUG_LOGGING: 1 | PYTHON_ENABLE_WORKER_EXTENSIONS: False. To enable debug level logging, please refer to https://aka.ms/python-enable-debug-logging
+[2026-09-05T00:45:14.498Z] Received WorkerMetadataRequest, request ID e42785bf-7670-4de1-a81d-b05df7b2b32d, function_path: /Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/function_app.py
+[2026-09-05T00:45:14.514Z] Indexed function app and found 1 functions
+[2026-09-05T00:45:14.514Z] Successfully processed FunctionMetadataRequest for functions: Function Name: hello, Function Binding: [('httpTrigger', 'req', ''), ('http', '$return', '')]. Deferred bindings enabled: False.
+[2026-09-05T00:45:14.531Z] 1 functions found (Worker)
+[2026-09-05T00:45:14.537Z] 1 functions loaded
+[2026-09-05T00:45:14.539Z] Looking for extension bundle Microsoft.Azure.Functions.ExtensionBundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle
+[2026-09-05T00:45:14.539Z] Applying platform release channel configuration LATEST. Bundle version 4.37.1 will be used
+[2026-09-05T00:45:14.539Z] Found a matching extension bundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1
+[2026-09-05T00:45:14.539Z] Fetching information on versions of extension bundle Microsoft.Azure.Functions.ExtensionBundle available on https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index.json
+[2026-09-05T00:45:15.199Z] Applying platform release channel configuration LATEST. Bundle version 4.37.1 will be used
+[2026-09-05T00:45:15.199Z] Skipping bundle download since it already exists at path /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1
+[2026-09-05T00:45:15.200Z] Loading extension bundle from /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1/bin
+[2026-09-05T00:45:15.200Z] Script Startup resetting load context with base path: '/Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1/bin'.
+[2026-09-05T00:45:15.209Z] Reading host configuration file '/Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/host.json'
+[2026-09-05T00:45:15.209Z] Host configuration file read:
+[2026-09-05T00:45:15.209Z] {
+[2026-09-05T00:45:15.209Z]   "version": "2.0",
+[2026-09-05T00:45:15.209Z]   "logging": {
+[2026-09-05T00:45:15.209Z]     "logLevel": {
+[2026-09-05T00:45:15.209Z]       "default": "Information",
+[2026-09-05T00:45:15.209Z]       "Microsoft.Azure.WebJobs.Script.Grpc": "Trace",
+[2026-09-05T00:45:15.209Z]       "Worker": "Trace",
+[2026-09-05T00:45:15.209Z]       "Host.Function.Console": "Trace"
+[2026-09-05T00:45:15.209Z]     }
+[2026-09-05T00:45:15.209Z]   },
+[2026-09-05T00:45:15.209Z]   "extensionBundle": {
+[2026-09-05T00:45:15.209Z]     "id": "Microsoft.Azure.Functions.ExtensionBundle",
+[2026-09-05T00:45:15.209Z]     "version": "[4.*, 5.0.0)"
+[2026-09-05T00:45:15.209Z]   }
+[2026-09-05T00:45:15.209Z] }
+[2026-09-05T00:45:15.236Z] Starting host metrics provider.
+[2026-09-05T00:45:15.298Z] Initializing Warmup Extension.
+[2026-09-05T00:45:15.340Z] Initializing Host. OperationId: 'de8ee930-7b72-4550-a78a-2f7520c7fca2'.
+[2026-09-05T00:45:15.343Z] Host initialization: ConsecutiveErrors=0, StartupCount=1, OperationId=de8ee930-7b72-4550-a78a-2f7520c7fca2
+[2026-09-05T00:45:15.361Z] LoggerFilterOptions
+[2026-09-05T00:45:15.361Z] {
+[2026-09-05T00:45:15.361Z]   "MinLevel": "None",
+[2026-09-05T00:45:15.361Z]   "Rules": [
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": "Microsoft.Hosting.Lifetime",
+[2026-09-05T00:45:15.361Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.361Z]       "Filter": null
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.361Z]       "Filter": null
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": null,
+[2026-09-05T00:45:15.361Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": null,
+[2026-09-05T00:45:15.361Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": null,
+[2026-09-05T00:45:15.361Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": "Worker",
+[2026-09-05T00:45:15.361Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.361Z]       "Filter": null
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Microsoft.Azure.WebJobs.Script.Grpc",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Host.Function.Console",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Information",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     }
+[2026-09-05T00:45:15.362Z]   ]
+[2026-09-05T00:45:15.362Z] }
+[2026-09-05T00:45:15.362Z] LoggerFilterOptions
+[2026-09-05T00:45:15.362Z] {
+[2026-09-05T00:45:15.362Z]   "MinLevel": "None",
+[2026-09-05T00:45:15.362Z]   "Rules": [
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Microsoft.Hosting.Lifetime",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Worker",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Microsoft.Azure.WebJobs.Script.Grpc",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": null,
+[2026-09-05T00:45:15.363Z]       "CategoryName": "Host.Function.Console",
+[2026-09-05T00:45:15.363Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.363Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": null,
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": "Information",
+[2026-09-05T00:45:15.363Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.363Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": null,
+[2026-09-05T00:45:15.363Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": null,
+[2026-09-05T00:45:15.363Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.363Z]     }
+[2026-09-05T00:45:15.363Z]   ]
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] HttpWorkerOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "Type": 0,
+[2026-09-05T00:45:15.363Z]   "Description": null,
+[2026-09-05T00:45:15.363Z]   "Arguments": null,
+[2026-09-05T00:45:15.363Z]   "Port": 56876,
+[2026-09-05T00:45:15.363Z]   "IsPortManuallySet": false,
+[2026-09-05T00:45:15.363Z]   "EnableForwardingHttpRequest": false,
+[2026-09-05T00:45:15.363Z]   "EnableProxyingHttpRequest": false,
+[2026-09-05T00:45:15.363Z]   "InitializationTimeout": "00:00:30",
+[2026-09-05T00:45:15.363Z]   "CustomRoutesEnabled": false,
+[2026-09-05T00:45:15.363Z]   "Http": null
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] FunctionResultAggregatorOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "BatchSize": 1000,
+[2026-09-05T00:45:15.363Z]   "FlushTimeout": "00:00:30",
+[2026-09-05T00:45:15.363Z]   "IsEnabled": true
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] ConcurrencyOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "DynamicConcurrencyEnabled": false,
+[2026-09-05T00:45:15.363Z]   "MaximumFunctionConcurrency": 500,
+[2026-09-05T00:45:15.363Z]   "CPUThreshold": 0.8,
+[2026-09-05T00:45:15.363Z]   "SnapshotPersistenceEnabled": true
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] SingletonOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "LockPeriod": "00:00:15",
+[2026-09-05T00:45:15.363Z]   "ListenerLockPeriod": "00:00:15",
+[2026-09-05T00:45:15.363Z]   "LockAcquisitionTimeout": "10675199.02:48:05.4775807",
+[2026-09-05T00:45:15.363Z]   "LockAcquisitionPollingInterval": "00:00:05",
+[2026-09-05T00:45:15.363Z]   "ListenerLockRecoveryPollingInterval": "00:01:00"
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] ScaleOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "ScaleMetricsMaxAge": "00:02:00",
+[2026-09-05T00:45:15.363Z]   "ScaleMetricsSampleInterval": "00:00:10",
+[2026-09-05T00:45:15.363Z]   "MetricsPurgeEnabled": true,
+[2026-09-05T00:45:15.363Z]   "IsTargetScalingEnabled": true,
+[2026-09-05T00:45:15.363Z]   "IsRuntimeScalingEnabled": false
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.364Z] Starting JobHost
+[2026-09-05T00:45:15.366Z] Starting Host (HostId=yeongseonsmacbookpro-1250692316, InstanceId=c61913f6-6bf1-4ff1-aea8-e6be9a19c531, Version=4.1045.200.25556, ProcessId=98657, AppDomainId=1, InDebugMode=False, InDiagnosticMode=False, FunctionsExtensionVersion=(null))
+[2026-09-05T00:45:15.369Z] Loading functions metadata
+[2026-09-05T00:45:15.369Z] Worker indexing is enabled
+[2026-09-05T00:45:15.369Z] Fetching metadata for workerRuntime: python
+[2026-09-05T00:45:15.369Z] Reading functions metadata (Worker)
+[2026-09-05T00:45:15.372Z] Reading functions metadata (Custom)
+[2026-09-05T00:45:15.377Z] 0 functions found (Custom)
+[2026-09-05T00:45:15.381Z] 1 functions loaded
+[2026-09-05T00:45:15.401Z] Generating 1 job function(s)
+[2026-09-05T00:45:15.402Z] Worker process started and initialized.
+[2026-09-05T00:45:15.405Z] Received WorkerLoadRequest, request ID e42785bf-7670-4de1-a81d-b05df7b2b32d, function_id: 4d71d03f-f19b-5d9e-8523-9628ba18063c,function_name: hello, function_app_directory : /Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger
+[2026-09-05T00:45:15.405Z] Successfully processed FunctionLoadRequest, request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, function ID: 4d71d03f-f19b-5d9e-8523-9628ba18063c,function Name: hello,programming model: V2
+[2026-09-05T00:45:15.423Z] Found the following functions:
+[2026-09-05T00:45:15.423Z] Host.Functions.hello
+[2026-09-05T00:45:15.423Z] 
+[2026-09-05T00:45:15.427Z] HttpOptions
+[2026-09-05T00:45:15.427Z] {
+[2026-09-05T00:45:15.427Z]   "DynamicThrottlesEnabled": false,
+[2026-09-05T00:45:15.427Z]   "EnableChunkedRequestBinding": false,
+[2026-09-05T00:45:15.427Z]   "MaxConcurrentRequests": -1,
+[2026-09-05T00:45:15.427Z]   "MaxOutstandingRequests": -1,
+[2026-09-05T00:45:15.427Z]   "RoutePrefix": "api"
+[2026-09-05T00:45:15.427Z] }
+[2026-09-05T00:45:15.427Z] Initializing function HTTP routes
+[2026-09-05T00:45:15.427Z] Mapped function route 'api/hello' [all] to 'hello'
+[2026-09-05T00:45:15.427Z] 
+[2026-09-05T00:45:15.430Z] Host initialized (61ms)
+[2026-09-05T00:45:15.431Z] Host started (65ms)
+[2026-09-05T00:45:15.431Z] Job host started
+
+Functions:
+
+	hello:  http://localhost:7071/api/hello
+
+[2026-09-05T00:45:16.955Z] Executing HTTP request: {
+[2026-09-05T00:45:16.955Z]   "requestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+[2026-09-05T00:45:16.955Z]   "method": "GET",
+[2026-09-05T00:45:16.955Z]   "userAgent": "curl/8.7.1",
+[2026-09-05T00:45:16.955Z]   "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.FAKEpayload.FAKEsignature",
+[2026-09-05T00:45:16.955Z]   "uri": "/api/hello?code=Zm9vYmFyZmFrZWZ1bmN0aW9ua2V5MTIzNDU2Nzg5MA=="
+[2026-09-05T00:45:16.955Z] }
+[2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='This function was programmatically called via the host APIs.', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)
+[2026-09-05T00:45:17.227Z] Received FunctionInvocationRequest, request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, function ID: 4d71d03f-f19b-5d9e-8523-9628ba18063c, function name: hello, invocation ID: 6a8f3658-2b31-4554-aa86-1ee32a9e679b, function type: sync, timestamp (UTC): 2026-09-05 00:45:17.226806, sync threadpool max workers: 1000
+[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Failed, Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b, Duration=54ms)
+[2026-09-05T00:45:17.249Z] Executed HTTP request: {
+[2026-09-05T00:45:17.249Z]   "requestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+[2026-09-05T00:45:17.249Z]   "identities": "(WebJobsAuthLevel:Admin)",
+[2026-09-05T00:45:17.249Z]   "status": "500",
+[2026-09-05T00:45:17.249Z]   "duration": "294"
+[2026-09-05T00:45:17.249Z] }
+[2026-09-05T00:45:20.363Z] Host lock lease acquired by instance ID '0000000000000000000000003419A628'.

--- a/src/funcviz/parser/core.py
+++ b/src/funcviz/parser/core.py
@@ -57,7 +57,7 @@ def parse_trace(
     raw_events = synthesize_application_events(extract_events(folded))
     finalized = finalize_events(raw_events)
     intervals = build_intervals(finalized, raw_events)
-    lanes = build_lanes(finalized)
+    lanes = build_lanes(finalized, raw_events)
     failures = build_failures(finalized, raw_events)
 
     meta = _scan_metadata(folded)

--- a/src/funcviz/parser/derive.py
+++ b/src/funcviz/parser/derive.py
@@ -36,6 +36,10 @@ _FAIL_APPLICATION_REASON = (
     "No invocation reached the function body; indexing failed before the function was loaded."
 )
 
+_INVOCATION_FAILED_HOST_REASON = (
+    "The host reported the invocation failed; the run stopped in the function body."
+)
+
 
 _APPLICATION_INTERVAL_LABEL = "Application (inferred window)"
 
@@ -47,14 +51,19 @@ def synthesize_application_events(
 
     The application lane has no dedicated log line (docs/event-coverage.md): user
     code entry/exit is inferred from the surrounding observed events. When a
-    success trace pairs a ``WorkerReceivedInvocation`` with a matching later
+    trace pairs a ``WorkerReceivedInvocation`` with a matching later
     ``InvocationCompleted`` (same ``invocationId``), we synthesize an
     ``ApplicationFunctionStarted`` immediately after the worker received the
-    invocation and an ``ApplicationFunctionCompleted`` immediately before the host
-    reported completion, so the lane owns the two markers FR-4 requires. These are
+    invocation and, when the invocation succeeded, an
+    ``ApplicationFunctionCompleted`` immediately before the host reported
+    completion, so the lane owns the markers FR-4 requires. These are
     inferences, not log records, so they carry ``confidence = INFERRED`` and
-    ``raw = None``. Failure traces (indexing never reached the function body)
-    synthesize nothing and leave the application lane empty.
+    ``raw = None``. When the invocation failed (``result == "Failed"``) we
+    synthesize only ``ApplicationFunctionStarted``: user code was entered but
+    never completed normally, so fabricating a completion marker would imply a
+    success that did not happen. Worker-startup failure traces (indexing never
+    reached the function body) synthesize nothing and leave the application lane
+    empty.
     """
     names = {str(e["event"]) for e in raw_events}
     if names & {"ApplicationFunctionStarted", "ApplicationFunctionCompleted"}:
@@ -75,6 +84,7 @@ def synthesize_application_events(
         return list(raw_events)
 
     invocation_id = worker.get("invocationId")
+    invocation_failed = completed.get("result") == "Failed"
 
     started = {
         "event": "ApplicationFunctionStarted",
@@ -95,7 +105,7 @@ def synthesize_application_events(
 
     result: list[dict[str, object]] = []
     for event in raw_events:
-        if event is completed:
+        if event is completed and not invocation_failed:
             result.append(finished)
         result.append(event)
         if event is worker:
@@ -219,7 +229,7 @@ def build_intervals(events: list[Event], raw_events: list[dict[str, object]]) ->
     return intervals
 
 
-def build_lanes(events: list[Event]) -> Lanes:
+def build_lanes(events: list[Event], raw_events: list[dict[str, object]]) -> Lanes:
     failed = next((e for e in events if e.event == "WorkerIndexingFailed"), None)
     if failed is not None:
         return Lanes(
@@ -245,16 +255,27 @@ def build_lanes(events: list[Event]) -> Lanes:
     host_reached = bool(names & {"InvocationStarted", "InvocationCompleted"})
     worker_reached = "WorkerReceivedInvocation" in names
 
+    invocation_failure = _failed_invocation_event(events, raw_events)
+    if invocation_failure is not None:
+        host_status = LaneStatus(
+            LaneState.FAILED_HERE,
+            Confidence.OBSERVED,
+            reason=_INVOCATION_FAILED_HOST_REASON,
+            failure_event=invocation_failure,
+        )
+    else:
+        host_status = LaneStatus(
+            LaneState.REACHED if host_reached else LaneState.NOT_REACHED,
+            Confidence.OBSERVED,
+        )
+
     return Lanes(
         client=LaneStatus(
             LaneState.REACHED if client_reached else LaneState.NOT_REACHED,
             Confidence.INFERRED,
             reason=_CLIENT_REASON,
         ),
-        host=LaneStatus(
-            LaneState.REACHED if host_reached else LaneState.NOT_REACHED,
-            Confidence.OBSERVED,
-        ),
+        host=host_status,
         python_worker=LaneStatus(
             LaneState.REACHED if worker_reached else LaneState.NOT_REACHED,
             Confidence.OBSERVED,
@@ -269,11 +290,31 @@ def build_lanes(events: list[Event]) -> Lanes:
 
 def build_failures(events: list[Event], raw_events: list[dict[str, object]]) -> list[Failure]:
     failed = next((e for e in events if e.event == "WorkerIndexingFailed"), None)
-    if failed is None:
-        return []
-    raw_by_name = {str(r["event"]): r for r in raw_events}
-    message = _opt_str(raw_by_name.get("WorkerIndexingFailed", {}).get("failureMessage"))
-    return [Failure(event=failed.id, kind="worker-indexing", message=message)]
+    if failed is not None:
+        raw_by_name = {str(r["event"]): r for r in raw_events}
+        message = _opt_str(raw_by_name.get("WorkerIndexingFailed", {}).get("failureMessage"))
+        return [Failure(event=failed.id, kind="worker-indexing", message=message)]
+
+    invocation_failure = _failed_invocation_event(events, raw_events)
+    if invocation_failure is not None:
+        return [Failure(event=invocation_failure, kind="invocation-failed")]
+    return []
+
+
+def _failed_invocation_event(
+    events: list[Event], raw_events: list[dict[str, object]]
+) -> str | None:
+    """Return the finalized event id of a failed ``InvocationCompleted``, if any.
+
+    An in-invocation failure is a host ``InvocationCompleted`` whose parsed
+    ``result`` is ``"Failed"`` (the ``Executed 'Functions.x' (Failed, ...)``
+    line). v0.1 has no distinct ``InvocationFailed`` log line, so this is the
+    single anchor the viewer uses to render the host lane's stop.
+    """
+    raw_completed = next((r for r in raw_events if r["event"] == "InvocationCompleted"), None)
+    if raw_completed is None or raw_completed.get("result") != "Failed":
+        return None
+    return next((e.id for e in events if e.event == "InvocationCompleted"), None)
 
 
 def _as_lane(value: object) -> Lane:

--- a/tests/test_parser_invocation_fail.py
+++ b/tests/test_parser_invocation_fail.py
@@ -1,0 +1,82 @@
+"""In-invocation failure derivation for a function-body failure (issue #27).
+
+Asserts that ``invocation-fail.log`` (a run that reached user code and then
+failed, reported by the host's ``Executed 'Functions.hello' (Failed, ...)`` line
+and an HTTP 500) parses into a schema-valid ``outcome: failure`` trace that the
+viewer can render: the host lane owns the stop via ``failed-here`` +
+``failureEvent``, the client/worker/application lanes stay reached (the failure
+happened inside the function body, not before it), no misleading
+``ApplicationFunctionCompleted`` marker is synthesized, and the application
+interval is omitted. A byte-for-byte golden guards ``traces/invocation-fail.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from funcviz.parser import from_log_text, mask_records, parse_trace
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
+
+INVOCATION_FAIL_EVENTS = [
+    "HttpRequestReceived",
+    "InvocationStarted",
+    "WorkerReceivedInvocation",
+    "ApplicationFunctionStarted",
+    "InvocationCompleted",
+    "HttpResponseReturned",
+]
+
+
+def _parsed() -> dict[str, object]:
+    text = (ROOT / "samples" / "invocation-fail.log").read_text()
+    return parse_trace(mask_records(from_log_text(text)), trace_id="invocation-fail-001").to_dict()
+
+
+def test_invocation_fail_log_validates_against_schema():
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(_parsed()))
+
+
+def test_outcome_is_failure_from_the_executed_failed_line():
+    assert _parsed()["outcome"] == "failure"
+
+
+def test_event_vocabulary_omits_the_application_completion_marker():
+    names = [e["event"] for e in _parsed()["events"]]
+    assert names == INVOCATION_FAIL_EVENTS
+    assert "ApplicationFunctionCompleted" not in names
+
+
+def test_host_lane_owns_the_stop_at_the_failed_invocation():
+    lanes = _parsed()["lanes"]
+    completed = next(e for e in _parsed()["events"] if e["event"] == "InvocationCompleted")
+    assert lanes["host"]["status"] == "failed-here"
+    assert lanes["host"]["failureEvent"] == completed["id"]
+
+
+def test_lanes_reached_before_the_failure_stay_reached():
+    lanes = _parsed()["lanes"]
+    assert lanes["client"]["status"] == "reached"
+    assert lanes["python-worker"]["status"] == "reached"
+    assert lanes["application"]["status"] == "reached"
+
+
+def test_failure_record_anchors_the_failed_invocation_without_a_fabricated_message():
+    failures = _parsed()["failures"]
+    completed = next(e for e in _parsed()["events"] if e["event"] == "InvocationCompleted")
+    assert failures == [{"event": completed["id"], "kind": "invocation-failed"}]
+
+
+def test_no_application_interval_for_a_run_that_never_completed_the_body():
+    interval_ids = [i["id"] for i in _parsed()["intervals"]]
+    assert "i4" not in interval_ids
+    assert interval_ids == ["i1", "i2", "i3"]
+
+
+def test_parser_output_matches_committed_golden():
+    golden = json.loads((ROOT / "traces" / "invocation-fail.json").read_text())
+    assert _parsed() == golden

--- a/traces/invocation-fail.json
+++ b/traces/invocation-fail.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "0.1",
+  "traceId": "invocation-fail-001",
+  "outcome": "failure",
+  "input": {
+    "source": "core-tools-log",
+    "adapter": "CoreToolsLogAdapter",
+    "adapterVersion": "0.1"
+  },
+  "runtime": {
+    "environment": "local",
+    "language": "python",
+    "trigger": "http",
+    "coreToolsVersion": "4.6.0+ab90faafcab539d63cd3d0ce5faf1bca4395fccc",
+    "hostVersion": "4.1045.200.25556"
+  },
+  "application": {
+    "functionName": "hello",
+    "sourceFile": "function_app.py"
+  },
+  "lanes": {
+    "client": {
+      "status": "reached",
+      "confidence": "inferred",
+      "reason": "Derived from host HTTP request/response lines."
+    },
+    "host": {
+      "status": "failed-here",
+      "confidence": "observed",
+      "reason": "The host reported the invocation failed; the run stopped in the function body.",
+      "failureEvent": "e4"
+    },
+    "python-worker": {
+      "status": "reached",
+      "confidence": "observed"
+    },
+    "application": {
+      "status": "reached",
+      "confidence": "inferred",
+      "reason": "User-code entry/exit is not separately logged."
+    }
+  },
+  "events": [
+    {
+      "id": "e0",
+      "sequence": 0,
+      "timestamp": "2026-09-05T00:45:16.955Z",
+      "elapsedMs": 0,
+      "lane": "client",
+      "event": "HttpRequestReceived",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:16.955Z] Executing HTTP request: {\n[2026-09-05T00:45:16.955Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:16.955Z]   \"method\": \"GET\",\n[2026-09-05T00:45:16.955Z]   \"userAgent\": \"curl/8.7.1\",\n[2026-09-05T00:45:16.955Z]   \"Authorization\": \"Bearer [REDACTED:bearer-token]\",\n[2026-09-05T00:45:16.955Z]   \"uri\": \"/api/hello?code=[REDACTED:function-key]\"\n[2026-09-05T00:45:16.955Z] }"
+    },
+    {
+      "id": "e1",
+      "sequence": 1,
+      "timestamp": "2026-09-05T00:45:17.206Z",
+      "elapsedMs": 251,
+      "lane": "host",
+      "event": "InvocationStarted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='This function was programmatically called via the host APIs.', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)"
+    },
+    {
+      "id": "e2",
+      "sequence": 2,
+      "timestamp": "2026-09-05T00:45:17.227Z",
+      "elapsedMs": 272,
+      "lane": "python-worker",
+      "event": "WorkerReceivedInvocation",
+      "workerRequestId": "e42785bf-7670-4de1-a81d-b05df7b2b32d",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.227Z] Received FunctionInvocationRequest, request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, function ID: 4d71d03f-f19b-5d9e-8523-9628ba18063c, function name: hello, invocation ID: 6a8f3658-2b31-4554-aa86-1ee32a9e679b, function type: sync, timestamp (UTC): 2026-09-05 00:45:17.226806, sync threadpool max workers: 1000"
+    },
+    {
+      "id": "e3",
+      "sequence": 3,
+      "timestamp": "2026-09-05T00:45:17.227Z",
+      "elapsedMs": 272,
+      "lane": "application",
+      "event": "ApplicationFunctionStarted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "inferred",
+      "raw": null
+    },
+    {
+      "id": "e4",
+      "sequence": 4,
+      "timestamp": "2026-09-05T00:45:17.240Z",
+      "elapsedMs": 285,
+      "lane": "host",
+      "event": "InvocationCompleted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Failed, Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b, Duration=54ms)"
+    },
+    {
+      "id": "e5",
+      "sequence": 5,
+      "timestamp": "2026-09-05T00:45:17.249Z",
+      "elapsedMs": 294,
+      "lane": "client",
+      "event": "HttpResponseReturned",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:17.249Z] Executed HTTP request: {\n[2026-09-05T00:45:17.249Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:17.249Z]   \"identities\": \"(WebJobsAuthLevel:Admin)\",\n[2026-09-05T00:45:17.249Z]   \"status\": \"500\",\n[2026-09-05T00:45:17.249Z]   \"duration\": \"294\"\n[2026-09-05T00:45:17.249Z] }"
+    }
+  ],
+  "intervals": [
+    {
+      "id": "i1",
+      "label": "Invocation (host log delta)",
+      "lane": "host",
+      "kind": "invocation",
+      "startEvent": "e1",
+      "endEvent": "e4",
+      "durationMs": 34,
+      "source": "log-delta",
+      "confidence": "observed"
+    },
+    {
+      "id": "i2",
+      "label": "Invocation (host-reported)",
+      "lane": "host",
+      "kind": "invocation",
+      "startEvent": "e1",
+      "endEvent": "e4",
+      "durationMs": 54,
+      "source": "host-reported",
+      "confidence": "observed",
+      "raw": "Duration=54ms"
+    },
+    {
+      "id": "i3",
+      "label": "HTTP request",
+      "lane": "client",
+      "kind": "http",
+      "startEvent": "e0",
+      "endEvent": "e5",
+      "durationMs": 294,
+      "source": "http-reported",
+      "confidence": "inferred",
+      "raw": "\"duration\": \"294\""
+    }
+  ],
+  "failures": [
+    {
+      "event": "e4",
+      "kind": "invocation-failed"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fixes #27: an in-invocation function-body failure now renders the viewer's "Run stopped here" anchor. Previously such a run (`Executed 'Functions.hello' (Failed, ...)` + HTTP 500) parsed as `outcome:failure` but left **no** lane `failed-here`, so the frozen viewer showed no stop.
- `build_lanes` marks the **host** lane `failed-here` with `failureEvent` on the failed `InvocationCompleted` — the only anchor the frozen `index.html` honors (`status==="failed-here" && event.id===failureEvent` on a rendered lane).
- Application synthesis emits only `ApplicationFunctionStarted` on failure (no fabricated `ApplicationFunctionCompleted`, no `i4` interval); `failures[]` gains a message-less `invocation-failed` record (the Failed host line carries no exception text).
- Strictly gated on `result=="Failed"`, so `success.json` and `worker-fail.json` goldens are byte-for-byte unchanged.

## Verification
- 113 tests pass (was 105); ruff + LSP clean.
- New `samples/invocation-fail.log`, `traces/invocation-fail.json` golden, and 8 tests in `tests/test_parser_invocation_fail.py`.
- Headless viewer render: host lane shows the stop anchor at the failed event, 0 console errors, 0 failed requests.
- Oracle design + implementation review: 94/100, no blocking fixes.

## Scope
Single-invocation v0.1. Multi-invocation logs and result vocabularies beyond `Succeeded|Failed` remain out of scope (noted by Oracle).