### PR TITLE
feat(parser): emit unknown lane state for unobservable worker/app lanes (#28)

### DIFF
--- a/samples/worker-unobserved.log
+++ b/samples/worker-unobserved.log
@@ -1,0 +1,337 @@
+'local.settings.json' found in root directory (/Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger).
+Resolving worker runtime to 'python'.
+Found Python version 3.12.14 (python3).
+Selected out-of-process host.
+
+
+                  %%%%%%
+                 %%%%%%
+            @   %%%%%%    @
+          @@   %%%%%%      @@
+       @@@    %%%%%%%%%%%    @@@
+     @@      %%%%%%%%%%        @@
+       @@         %%%%       @@
+         @@      %%%       @@
+           @@    %%      @@
+                %%
+                %
+
+
+Azure Functions Core Tools
+Core Tools Version:       4.6.0+ab90faafcab539d63cd3d0ce5faf1bca4395fccc (64-bit)
+Function Runtime Version: 4.1045.200.25556
+
+[2026-09-05T00:45:11.402Z] Building host: version spec: , startup suppressed: 'False', configuration suppressed: 'False', startup operation id: 'de8ee930-7b72-4550-a78a-2f7520c7fca2'
+[2026-09-05T00:45:11.480Z] Reading host configuration file '/Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/host.json'
+[2026-09-05T00:45:11.480Z] Host configuration file read:
+[2026-09-05T00:45:11.480Z] {
+[2026-09-05T00:45:11.480Z]   "version": "2.0",
+[2026-09-05T00:45:11.480Z]   "logging": {
+[2026-09-05T00:45:11.480Z]     "logLevel": {
+[2026-09-05T00:45:11.480Z]       "default": "Information",
+[2026-09-05T00:45:11.480Z]       "Microsoft.Azure.WebJobs.Script.Grpc": "Trace",
+[2026-09-05T00:45:11.480Z]       "Worker": "Trace",
+[2026-09-05T00:45:11.481Z]       "Host.Function.Console": "Trace"
+[2026-09-05T00:45:11.481Z]     }
+[2026-09-05T00:45:11.481Z]   },
+[2026-09-05T00:45:11.481Z]   "extensionBundle": {
+[2026-09-05T00:45:11.481Z]     "id": "Microsoft.Azure.Functions.ExtensionBundle",
+[2026-09-05T00:45:11.481Z]     "version": "[4.*, 5.0.0)"
+[2026-09-05T00:45:11.481Z]   }
+[2026-09-05T00:45:11.481Z] }
+[2026-09-05T00:45:11.494Z] Looking for extension bundle Microsoft.Azure.Functions.ExtensionBundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle
+[2026-09-05T00:45:11.495Z] Applying platform release channel configuration LATEST. Bundle version 4.37.1 will be used
+[2026-09-05T00:45:11.495Z] Found a matching extension bundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1
+[2026-09-05T00:45:11.518Z] Loading functions metadata
+[2026-09-05T00:45:11.519Z] Worker indexing is enabled
+[2026-09-05T00:45:11.520Z] Fetching metadata for workerRuntime: python
+[2026-09-05T00:45:11.520Z] Reading functions metadata (Worker)
+[2026-09-05T00:45:11.803Z]  INFO: Starting Azure Functions Python Worker.
+[2026-09-05T00:45:11.803Z]  INFO: Worker ID: f17a18d1-fb59-43c9-af61-a80e59f4ca50, Request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, Host Address: 127.0.0.1:56863
+[2026-09-05T00:45:12.112Z]  INFO: Successfully opened gRPC channel to 127.0.0.1:56863 
+[2026-09-05T00:45:12.112Z]  INFO: Detaching console logging.
+[2026-09-05T00:45:14.155Z] Switched to gRPC logging.
+[2026-09-05T00:45:14.166Z] Received WorkerInitRequest, python version 3.12.14 (main, Aug 12 2026, 13:57:54) [Clang 21.0.0 (clang-2100.1.1.101)], worker version 4.40.2, request ID e42785bf-7670-4de1-a81d-b05df7b2b32d. App Settings state: PYTHON_THREADPOOL_THREAD_COUNT: 1000 | PYTHON_ENABLE_DEBUG_LOGGING: 1 | PYTHON_ENABLE_WORKER_EXTENSIONS: False. To enable debug level logging, please refer to https://aka.ms/python-enable-debug-logging
+[2026-09-05T00:45:14.498Z] Received WorkerMetadataRequest, request ID e42785bf-7670-4de1-a81d-b05df7b2b32d, function_path: /Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/function_app.py
+[2026-09-05T00:45:14.514Z] Indexed function app and found 1 functions
+[2026-09-05T00:45:14.514Z] Successfully processed FunctionMetadataRequest for functions: Function Name: hello, Function Binding: [('httpTrigger', 'req', ''), ('http', '$return', '')]. Deferred bindings enabled: False.
+[2026-09-05T00:45:14.531Z] 1 functions found (Worker)
+[2026-09-05T00:45:14.537Z] 1 functions loaded
+[2026-09-05T00:45:14.539Z] Looking for extension bundle Microsoft.Azure.Functions.ExtensionBundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle
+[2026-09-05T00:45:14.539Z] Applying platform release channel configuration LATEST. Bundle version 4.37.1 will be used
+[2026-09-05T00:45:14.539Z] Found a matching extension bundle at /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1
+[2026-09-05T00:45:14.539Z] Fetching information on versions of extension bundle Microsoft.Azure.Functions.ExtensionBundle available on https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index.json
+[2026-09-05T00:45:15.199Z] Applying platform release channel configuration LATEST. Bundle version 4.37.1 will be used
+[2026-09-05T00:45:15.199Z] Skipping bundle download since it already exists at path /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1
+[2026-09-05T00:45:15.200Z] Loading extension bundle from /Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1/bin
+[2026-09-05T00:45:15.200Z] Script Startup resetting load context with base path: '/Users/yeongseonchoe/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.37.1/bin'.
+[2026-09-05T00:45:15.209Z] Reading host configuration file '/Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger/host.json'
+[2026-09-05T00:45:15.209Z] Host configuration file read:
+[2026-09-05T00:45:15.209Z] {
+[2026-09-05T00:45:15.209Z]   "version": "2.0",
+[2026-09-05T00:45:15.209Z]   "logging": {
+[2026-09-05T00:45:15.209Z]     "logLevel": {
+[2026-09-05T00:45:15.209Z]       "default": "Information",
+[2026-09-05T00:45:15.209Z]       "Microsoft.Azure.WebJobs.Script.Grpc": "Trace",
+[2026-09-05T00:45:15.209Z]       "Worker": "Trace",
+[2026-09-05T00:45:15.209Z]       "Host.Function.Console": "Trace"
+[2026-09-05T00:45:15.209Z]     }
+[2026-09-05T00:45:15.209Z]   },
+[2026-09-05T00:45:15.209Z]   "extensionBundle": {
+[2026-09-05T00:45:15.209Z]     "id": "Microsoft.Azure.Functions.ExtensionBundle",
+[2026-09-05T00:45:15.209Z]     "version": "[4.*, 5.0.0)"
+[2026-09-05T00:45:15.209Z]   }
+[2026-09-05T00:45:15.209Z] }
+[2026-09-05T00:45:15.236Z] Starting host metrics provider.
+[2026-09-05T00:45:15.298Z] Initializing Warmup Extension.
+[2026-09-05T00:45:15.340Z] Initializing Host. OperationId: 'de8ee930-7b72-4550-a78a-2f7520c7fca2'.
+[2026-09-05T00:45:15.343Z] Host initialization: ConsecutiveErrors=0, StartupCount=1, OperationId=de8ee930-7b72-4550-a78a-2f7520c7fca2
+[2026-09-05T00:45:15.361Z] LoggerFilterOptions
+[2026-09-05T00:45:15.361Z] {
+[2026-09-05T00:45:15.361Z]   "MinLevel": "None",
+[2026-09-05T00:45:15.361Z]   "Rules": [
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": "Microsoft.Hosting.Lifetime",
+[2026-09-05T00:45:15.361Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.361Z]       "Filter": null
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.361Z]       "Filter": null
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": null,
+[2026-09-05T00:45:15.361Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": null,
+[2026-09-05T00:45:15.361Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": null,
+[2026-09-05T00:45:15.361Z]       "LogLevel": null,
+[2026-09-05T00:45:15.361Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.361Z]       "ProviderName": null,
+[2026-09-05T00:45:15.361Z]       "CategoryName": "Worker",
+[2026-09-05T00:45:15.361Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.361Z]       "Filter": null
+[2026-09-05T00:45:15.361Z]     },
+[2026-09-05T00:45:15.361Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Microsoft.Azure.WebJobs.Script.Grpc",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Host.Function.Console",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Information",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     }
+[2026-09-05T00:45:15.362Z]   ]
+[2026-09-05T00:45:15.362Z] }
+[2026-09-05T00:45:15.362Z] LoggerFilterOptions
+[2026-09-05T00:45:15.362Z] {
+[2026-09-05T00:45:15.362Z]   "MinLevel": "None",
+[2026-09-05T00:45:15.362Z]   "Rules": [
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Microsoft.Hosting.Lifetime",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": null,
+[2026-09-05T00:45:15.362Z]       "LogLevel": null,
+[2026-09-05T00:45:15.362Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Worker",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.362Z]     },
+[2026-09-05T00:45:15.362Z]     {
+[2026-09-05T00:45:15.362Z]       "ProviderName": null,
+[2026-09-05T00:45:15.362Z]       "CategoryName": "Microsoft.Azure.WebJobs.Script.Grpc",
+[2026-09-05T00:45:15.362Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.362Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": null,
+[2026-09-05T00:45:15.363Z]       "CategoryName": "Host.Function.Console",
+[2026-09-05T00:45:15.363Z]       "LogLevel": "Trace",
+[2026-09-05T00:45:15.363Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": null,
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": "Information",
+[2026-09-05T00:45:15.363Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": "None",
+[2026-09-05T00:45:15.363Z]       "Filter": null
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": "Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.SystemLoggerProvider",
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": null,
+[2026-09-05T00:45:15.363Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.363Z]     },
+[2026-09-05T00:45:15.363Z]     {
+[2026-09-05T00:45:15.363Z]       "ProviderName": "Azure.Functions.Cli.Diagnostics.ColoredConsoleLoggerProvider",
+[2026-09-05T00:45:15.363Z]       "CategoryName": null,
+[2026-09-05T00:45:15.363Z]       "LogLevel": null,
+[2026-09-05T00:45:15.363Z]       "Filter": "<AddFilter>b__0"
+[2026-09-05T00:45:15.363Z]     }
+[2026-09-05T00:45:15.363Z]   ]
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] HttpWorkerOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "Type": 0,
+[2026-09-05T00:45:15.363Z]   "Description": null,
+[2026-09-05T00:45:15.363Z]   "Arguments": null,
+[2026-09-05T00:45:15.363Z]   "Port": 56876,
+[2026-09-05T00:45:15.363Z]   "IsPortManuallySet": false,
+[2026-09-05T00:45:15.363Z]   "EnableForwardingHttpRequest": false,
+[2026-09-05T00:45:15.363Z]   "EnableProxyingHttpRequest": false,
+[2026-09-05T00:45:15.363Z]   "InitializationTimeout": "00:00:30",
+[2026-09-05T00:45:15.363Z]   "CustomRoutesEnabled": false,
+[2026-09-05T00:45:15.363Z]   "Http": null
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] FunctionResultAggregatorOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "BatchSize": 1000,
+[2026-09-05T00:45:15.363Z]   "FlushTimeout": "00:00:30",
+[2026-09-05T00:45:15.363Z]   "IsEnabled": true
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] ConcurrencyOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "DynamicConcurrencyEnabled": false,
+[2026-09-05T00:45:15.363Z]   "MaximumFunctionConcurrency": 500,
+[2026-09-05T00:45:15.363Z]   "CPUThreshold": 0.8,
+[2026-09-05T00:45:15.363Z]   "SnapshotPersistenceEnabled": true
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] SingletonOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "LockPeriod": "00:00:15",
+[2026-09-05T00:45:15.363Z]   "ListenerLockPeriod": "00:00:15",
+[2026-09-05T00:45:15.363Z]   "LockAcquisitionTimeout": "10675199.02:48:05.4775807",
+[2026-09-05T00:45:15.363Z]   "LockAcquisitionPollingInterval": "00:00:05",
+[2026-09-05T00:45:15.363Z]   "ListenerLockRecoveryPollingInterval": "00:01:00"
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.363Z] ScaleOptions
+[2026-09-05T00:45:15.363Z] {
+[2026-09-05T00:45:15.363Z]   "ScaleMetricsMaxAge": "00:02:00",
+[2026-09-05T00:45:15.363Z]   "ScaleMetricsSampleInterval": "00:00:10",
+[2026-09-05T00:45:15.363Z]   "MetricsPurgeEnabled": true,
+[2026-09-05T00:45:15.363Z]   "IsTargetScalingEnabled": true,
+[2026-09-05T00:45:15.363Z]   "IsRuntimeScalingEnabled": false
+[2026-09-05T00:45:15.363Z] }
+[2026-09-05T00:45:15.364Z] Starting JobHost
+[2026-09-05T00:45:15.366Z] Starting Host (HostId=yeongseonsmacbookpro-1250692316, InstanceId=c61913f6-6bf1-4ff1-aea8-e6be9a19c531, Version=4.1045.200.25556, ProcessId=98657, AppDomainId=1, InDebugMode=False, InDiagnosticMode=False, FunctionsExtensionVersion=(null))
+[2026-09-05T00:45:15.369Z] Loading functions metadata
+[2026-09-05T00:45:15.369Z] Worker indexing is enabled
+[2026-09-05T00:45:15.369Z] Fetching metadata for workerRuntime: python
+[2026-09-05T00:45:15.369Z] Reading functions metadata (Worker)
+[2026-09-05T00:45:15.372Z] Reading functions metadata (Custom)
+[2026-09-05T00:45:15.377Z] 0 functions found (Custom)
+[2026-09-05T00:45:15.381Z] 1 functions loaded
+[2026-09-05T00:45:15.401Z] Generating 1 job function(s)
+[2026-09-05T00:45:15.402Z] Worker process started and initialized.
+[2026-09-05T00:45:15.405Z] Received WorkerLoadRequest, request ID e42785bf-7670-4de1-a81d-b05df7b2b32d, function_id: 4d71d03f-f19b-5d9e-8523-9628ba18063c,function_name: hello, function_app_directory : /Users/yeongseonchoe/GitHub/azure-functions-runtime-visualizer/examples/python-http-trigger
+[2026-09-05T00:45:15.405Z] Successfully processed FunctionLoadRequest, request ID: e42785bf-7670-4de1-a81d-b05df7b2b32d, function ID: 4d71d03f-f19b-5d9e-8523-9628ba18063c,function Name: hello,programming model: V2
+[2026-09-05T00:45:15.423Z] Found the following functions:
+[2026-09-05T00:45:15.423Z] Host.Functions.hello
+[2026-09-05T00:45:15.423Z] 
+[2026-09-05T00:45:15.427Z] HttpOptions
+[2026-09-05T00:45:15.427Z] {
+[2026-09-05T00:45:15.427Z]   "DynamicThrottlesEnabled": false,
+[2026-09-05T00:45:15.427Z]   "EnableChunkedRequestBinding": false,
+[2026-09-05T00:45:15.427Z]   "MaxConcurrentRequests": -1,
+[2026-09-05T00:45:15.427Z]   "MaxOutstandingRequests": -1,
+[2026-09-05T00:45:15.427Z]   "RoutePrefix": "api"
+[2026-09-05T00:45:15.427Z] }
+[2026-09-05T00:45:15.427Z] Initializing function HTTP routes
+[2026-09-05T00:45:15.427Z] Mapped function route 'api/hello' [all] to 'hello'
+[2026-09-05T00:45:15.427Z] 
+[2026-09-05T00:45:15.430Z] Host initialized (61ms)
+[2026-09-05T00:45:15.431Z] Host started (65ms)
+[2026-09-05T00:45:15.431Z] Job host started
+
+Functions:
+
+	hello:  http://localhost:7071/api/hello
+
+[2026-09-05T00:45:16.955Z] Executing HTTP request: {
+[2026-09-05T00:45:16.955Z]   "requestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+[2026-09-05T00:45:16.955Z]   "method": "GET",
+[2026-09-05T00:45:16.955Z]   "userAgent": "curl/8.7.1",
+[2026-09-05T00:45:16.955Z]   "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.FAKEpayload.FAKEsignature",
+[2026-09-05T00:45:16.955Z]   "uri": "/api/hello?code=Zm9vYmFyZmFrZWZ1bmN0aW9ua2V5MTIzNDU2Nzg5MA=="
+[2026-09-05T00:45:16.955Z] }
+[2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='This function was programmatically called via the host APIs.', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)
+[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Succeeded, Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b, Duration=54ms)
+[2026-09-05T00:45:17.249Z] Executed HTTP request: {
+[2026-09-05T00:45:17.249Z]   "requestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+[2026-09-05T00:45:17.249Z]   "identities": "(WebJobsAuthLevel:Admin)",
+[2026-09-05T00:45:17.249Z]   "status": "200",
+[2026-09-05T00:45:17.249Z]   "duration": "294"
+[2026-09-05T00:45:17.249Z] }
+[2026-09-05T00:45:20.363Z] Host lock lease acquired by instance ID '0000000000000000000000003419A628'.

--- a/src/funcviz/parser/derive.py
+++ b/src/funcviz/parser/derive.py
@@ -40,6 +40,12 @@ _INVOCATION_FAILED_HOST_REASON = (
     "The host reported the invocation failed; the run stopped in the function body."
 )
 
+_WORKER_UNKNOWN_REASON = (
+    "Host invocation was observed, but WorkerReceivedInvocation was absent; worker/gRPC debug "
+    "logging may not be enabled, so worker delivery is unknown."
+)
+_APPLICATION_UNKNOWN_REASON = "Application start was not inferred, and worker delivery is unknown."
+
 
 _APPLICATION_INTERVAL_LABEL = "Application (inferred window)"
 
@@ -269,6 +275,9 @@ def build_lanes(events: list[Event], raw_events: list[dict[str, object]]) -> Lan
             Confidence.OBSERVED,
         )
 
+    worker_status = _worker_status(worker_reached, host_reached)
+    application_status = _application_status(application_reached, worker_status.status)
+
     return Lanes(
         client=LaneStatus(
             LaneState.REACHED if client_reached else LaneState.NOT_REACHED,
@@ -276,16 +285,45 @@ def build_lanes(events: list[Event], raw_events: list[dict[str, object]]) -> Lan
             reason=_CLIENT_REASON,
         ),
         host=host_status,
-        python_worker=LaneStatus(
-            LaneState.REACHED if worker_reached else LaneState.NOT_REACHED,
-            Confidence.OBSERVED,
-        ),
-        application=LaneStatus(
-            LaneState.REACHED if application_reached else LaneState.NOT_REACHED,
-            Confidence.INFERRED,
-            reason=_APPLICATION_REASON,
-        ),
+        python_worker=worker_status,
+        application=application_status,
     )
+
+
+def _worker_status(worker_reached: bool, host_reached: bool) -> LaneStatus:
+    """Resolve the python-worker lane status (PRD FR-4.3, §9/§10).
+
+    ``WorkerReceivedInvocation`` is observable only when worker/gRPC debug
+    logging is elevated (§5). When it is absent we must not claim to have
+    *observed* a non-reach: if the host reached an invocation there was a
+    delivery whose worker-side signal we simply could not see, which is
+    ``unknown`` (unobservable), not ``not-reached``. Only when the host itself
+    never reached an invocation is the worker a causal ``not-reached`` (there was
+    no dispatch to observe). Neither absence case is directly observed, so both
+    carry ``inferred`` confidence rather than the overclaiming ``observed``.
+    """
+    if worker_reached:
+        return LaneStatus(LaneState.REACHED, Confidence.OBSERVED)
+    if host_reached:
+        return LaneStatus(LaneState.UNKNOWN, Confidence.INFERRED, reason=_WORKER_UNKNOWN_REASON)
+    return LaneStatus(LaneState.NOT_REACHED, Confidence.INFERRED)
+
+
+def _application_status(application_reached: bool, worker_state: LaneState) -> LaneStatus:
+    """Resolve the always-inferred application lane status.
+
+    The application window is inferred from the worker boundary (§10). When the
+    worker lane is ``unknown`` and no application start was inferred, we cannot
+    tell whether user code ran, so the application lane is ``unknown`` too rather
+    than a claimed ``not-reached``.
+    """
+    if application_reached:
+        return LaneStatus(LaneState.REACHED, Confidence.INFERRED, reason=_APPLICATION_REASON)
+    if worker_state is LaneState.UNKNOWN:
+        return LaneStatus(
+            LaneState.UNKNOWN, Confidence.INFERRED, reason=_APPLICATION_UNKNOWN_REASON
+        )
+    return LaneStatus(LaneState.NOT_REACHED, Confidence.INFERRED, reason=_APPLICATION_REASON)
 
 
 def build_failures(events: list[Event], raw_events: list[dict[str, object]]) -> list[Failure]:

--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -636,7 +636,7 @@
 
   var LANE_ORDER = ["client", "host", "python-worker"];
   var LANE_LABELS = { "client": "Client", "host": "Host", "python-worker": "Python Worker" };
-  var STATUS_LABELS = { "reached": "Reached", "failed-here": "Failed here", "not-reached": "Not reached" };
+  var STATUS_LABELS = { "reached": "Reached", "failed-here": "Failed here", "not-reached": "Not reached", "unknown": "Unknown" };
   var SOURCE_LABELS = { "log-delta": "log delta", "host-reported": "host reported", "http-reported": "HTTP reported" };
 
   /* confidence banner (#10) — includes the application lane, which has no
@@ -715,6 +715,7 @@
     var observed = [];
     var inferred = [];
     var notReached = [];
+    var unknown = [];
     var i;
     var key;
     var meta;
@@ -730,7 +731,9 @@
       if (status === "reached" || status === "failed-here") {
         if (meta.confidence === "inferred") inferred.push(key);
         else observed.push(key);
-      } else { /* not-reached / unknown / missing */
+      } else if (status === "unknown") {
+        unknown.push(key);
+      } else { /* not-reached / missing */
         notReached.push(key);
       }
     }
@@ -739,6 +742,7 @@
     banner.setAttribute("data-observed", observed.join(","));
     banner.setAttribute("data-inferred", inferred.join(","));
     banner.setAttribute("data-not-reached", notReached.join(","));
+    banner.setAttribute("data-unknown", unknown.join(","));
     banner.className = "confidence-banner" +
       (inferred.length ? "" : observed.length ? " confidence-banner--observed" : " confidence-banner--empty");
 
@@ -799,6 +803,10 @@
     clause("Inferred activity:", "conf-cat conf-cat--inferred", inferred);
     summary.appendChild(tx(" "));
     clause("Not reached:", "conf-cat conf-cat--not-reached", notReached);
+    if (unknown.length) {
+      summary.appendChild(tx(" "));
+      clause("Unknown/unobserved:", "conf-cat conf-cat--unknown", unknown);
+    }
     banner.appendChild(summary);
 
     banner.appendChild(el("p", "confidence-detail", detail));

--- a/tests/test_parser_worker_unobserved.py
+++ b/tests/test_parser_worker_unobserved.py
@@ -1,0 +1,73 @@
+"""Unknown-lane derivation for an un-elevated capture (issue #28).
+
+Asserts that ``worker-unobserved.log`` (a successful run captured without the §5
+elevated worker/gRPC logging, so the ``Received FunctionInvocationRequest``
+worker line is absent) does not claim to have *observed* a worker non-reach. The
+host still observes the invocation, so the worker boundary is genuinely
+``unknown`` rather than ``not-reached``; because the inferred application window
+hangs off that same absent worker signal, the application lane is ``unknown``
+too. Both carry ``inferred`` confidence, never the overclaiming ``observed``. A
+byte-for-byte golden guards ``traces/worker-unobserved.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from funcviz.parser import from_log_text, mask_records, parse_trace
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
+
+WORKER_UNOBSERVED_EVENTS = [
+    "HttpRequestReceived",
+    "InvocationStarted",
+    "InvocationCompleted",
+    "HttpResponseReturned",
+]
+
+
+def _parsed() -> dict[str, object]:
+    text = (ROOT / "samples" / "worker-unobserved.log").read_text()
+    return parse_trace(
+        mask_records(from_log_text(text)), trace_id="worker-unobserved-001"
+    ).to_dict()
+
+
+def test_worker_unobserved_log_validates_against_schema():
+    assert not list(Draft202012Validator(SCHEMA).iter_errors(_parsed()))
+
+
+def test_no_worker_or_application_events_are_fabricated():
+    names = [e["event"] for e in _parsed()["events"]]
+    assert names == WORKER_UNOBSERVED_EVENTS
+    assert "WorkerReceivedInvocation" not in names
+    assert "ApplicationFunctionStarted" not in names
+
+
+def test_observed_lanes_stay_observed():
+    lanes = _parsed()["lanes"]
+    assert lanes["client"]["status"] == "reached"
+    assert lanes["host"]["status"] == "reached"
+    assert lanes["host"]["confidence"] == "observed"
+
+
+def test_worker_lane_is_unknown_not_observed_not_reached():
+    worker = _parsed()["lanes"]["python-worker"]
+    assert worker["status"] == "unknown"
+    assert worker["confidence"] == "inferred"
+    assert worker.get("reason")
+
+
+def test_application_lane_propagates_unknown_from_the_worker():
+    application = _parsed()["lanes"]["application"]
+    assert application["status"] == "unknown"
+    assert application["confidence"] == "inferred"
+
+
+def test_parser_output_matches_committed_golden():
+    golden = json.loads((ROOT / "traces" / "worker-unobserved.json").read_text())
+    assert _parsed() == golden

--- a/traces/worker-unobserved.json
+++ b/traces/worker-unobserved.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": "0.1",
+  "traceId": "worker-unobserved-001",
+  "outcome": "success",
+  "input": {
+    "source": "core-tools-log",
+    "adapter": "CoreToolsLogAdapter",
+    "adapterVersion": "0.1"
+  },
+  "runtime": {
+    "environment": "local",
+    "language": "python",
+    "trigger": "http",
+    "coreToolsVersion": "4.6.0+ab90faafcab539d63cd3d0ce5faf1bca4395fccc",
+    "hostVersion": "4.1045.200.25556"
+  },
+  "application": {
+    "functionName": "hello",
+    "sourceFile": "function_app.py"
+  },
+  "lanes": {
+    "client": {
+      "status": "reached",
+      "confidence": "inferred",
+      "reason": "Derived from host HTTP request/response lines."
+    },
+    "host": {
+      "status": "reached",
+      "confidence": "observed"
+    },
+    "python-worker": {
+      "status": "unknown",
+      "confidence": "inferred",
+      "reason": "Host invocation was observed, but WorkerReceivedInvocation was absent; worker/gRPC debug logging may not be enabled, so worker delivery is unknown."
+    },
+    "application": {
+      "status": "unknown",
+      "confidence": "inferred",
+      "reason": "Application start was not inferred, and worker delivery is unknown."
+    }
+  },
+  "events": [
+    {
+      "id": "e0",
+      "sequence": 0,
+      "timestamp": "2026-09-05T00:45:16.955Z",
+      "elapsedMs": 0,
+      "lane": "client",
+      "event": "HttpRequestReceived",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:16.955Z] Executing HTTP request: {\n[2026-09-05T00:45:16.955Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:16.955Z]   \"method\": \"GET\",\n[2026-09-05T00:45:16.955Z]   \"userAgent\": \"curl/8.7.1\",\n[2026-09-05T00:45:16.955Z]   \"Authorization\": \"Bearer [REDACTED:bearer-token]\",\n[2026-09-05T00:45:16.955Z]   \"uri\": \"/api/hello?code=[REDACTED:function-key]\"\n[2026-09-05T00:45:16.955Z] }"
+    },
+    {
+      "id": "e1",
+      "sequence": 1,
+      "timestamp": "2026-09-05T00:45:17.206Z",
+      "elapsedMs": 251,
+      "lane": "host",
+      "event": "InvocationStarted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.206Z] Executing 'Functions.hello' (Reason='This function was programmatically called via the host APIs.', Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b)"
+    },
+    {
+      "id": "e2",
+      "sequence": 2,
+      "timestamp": "2026-09-05T00:45:17.240Z",
+      "elapsedMs": 285,
+      "lane": "host",
+      "event": "InvocationCompleted",
+      "invocationId": "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+      "confidence": "observed",
+      "raw": "[2026-09-05T00:45:17.240Z] Executed 'Functions.hello' (Succeeded, Id=6a8f3658-2b31-4554-aa86-1ee32a9e679b, Duration=54ms)"
+    },
+    {
+      "id": "e3",
+      "sequence": 3,
+      "timestamp": "2026-09-05T00:45:17.249Z",
+      "elapsedMs": 294,
+      "lane": "client",
+      "event": "HttpResponseReturned",
+      "httpRequestId": "2d0db691-8e70-4335-a8a9-e127715fa678",
+      "confidence": "inferred",
+      "raw": "[2026-09-05T00:45:17.249Z] Executed HTTP request: {\n[2026-09-05T00:45:17.249Z]   \"requestId\": \"2d0db691-8e70-4335-a8a9-e127715fa678\",\n[2026-09-05T00:45:17.249Z]   \"identities\": \"(WebJobsAuthLevel:Admin)\",\n[2026-09-05T00:45:17.249Z]   \"status\": \"200\",\n[2026-09-05T00:45:17.249Z]   \"duration\": \"294\"\n[2026-09-05T00:45:17.249Z] }"
+    }
+  ],
+  "intervals": [
+    {
+      "id": "i1",
+      "label": "Invocation (host log delta)",
+      "lane": "host",
+      "kind": "invocation",
+      "startEvent": "e1",
+      "endEvent": "e2",
+      "durationMs": 34,
+      "source": "log-delta",
+      "confidence": "observed"
+    },
+    {
+      "id": "i2",
+      "label": "Invocation (host-reported)",
+      "lane": "host",
+      "kind": "invocation",
+      "startEvent": "e1",
+      "endEvent": "e2",
+      "durationMs": 54,
+      "source": "host-reported",
+      "confidence": "observed",
+      "raw": "Duration=54ms"
+    },
+    {
+      "id": "i3",
+      "label": "HTTP request",
+      "lane": "client",
+      "kind": "http",
+      "startEvent": "e0",
+      "endEvent": "e3",
+      "durationMs": 294,
+      "source": "http-reported",
+      "confidence": "inferred",
+      "raw": "\"duration\": \"294\""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fixes #28: `LaneState.UNKNOWN` was defined but never emitted, and an un-elevated capture (no worker/gRPC debug logging) reported the worker lane as `not-reached` with `observed` confidence — claiming to have *observed* a non-reach that was actually unobservable.
- `build_lanes` now emits `unknown` (inferred) for the worker lane when the host reached an invocation but `WorkerReceivedInvocation` is absent, and propagates `unknown` to the inferred application window (which hangs off that same worker signal). A host that never reached an invocation still yields a causal `not-reached`. Absent-signal lanes carry `inferred`, never `observed`, confidence.
- Viewer: added the `Unknown` status label and partitioned `unknown` from `not-reached` in the confidence banner, so the UI never summarizes an unknown lane as "Not reached".

## Fixture
- New `samples/worker-unobserved.log` (success capture minus the worker `Received FunctionInvocationRequest` line) + byte golden `traces/worker-unobserved.json`, exercising both worker=unknown and application=unknown in one trace.

## Verification
- 119 tests pass (+6), ruff clean.
- Existing `success` / `worker-fail` / `invocation-fail` goldens byte-identical.
- Headless viewer: lane chips render `Unknown`, banner reads "Unknown/unobserved: Python Worker, Application", 0 console errors; existing trace banners unregressed.
- Design + implementation reviewed by Oracle (94/100).