### PR TITLE
fix(parser): redact MasterKey= and connection-URI userinfo (#29)

### DIFF
--- a/src/funcviz/parser/regexes.py
+++ b/src/funcviz/parser/regexes.py
@@ -208,6 +208,17 @@ _REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
         ),
         r"\1[REDACTED:function-key]",
     ),
+    # MasterKey=<value> is a function/master key in the same class as the
+    # header/query function-key rules above. The lookbehind stops it firing on
+    # a longer word ending in "MasterKey", and the negative lookahead makes a
+    # second pass a no-op (the marker is not re-captured as a value).
+    (
+        re.compile(
+            r"((?<![A-Za-z])MasterKey=" + _Q + r")(?!\[REDACTED:function-key\])" + _CONN_VALUE,
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:function-key]",
+    ),
     (re.compile(r"(AccountKey=)" + _CONN_VALUE, re.IGNORECASE), r"\1[REDACTED:storage-key]"),
     (
         re.compile(r"(SharedAccessKey=)(?!Name=)" + _CONN_VALUE, re.IGNORECASE),
@@ -218,6 +229,22 @@ _REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
     # Generic connection-string secrets (semicolon-delimited). AccessKey= is
     # guarded so it never re-fires on the tail of SharedAccessKey=.
     (re.compile(r"((?:Password|Pwd)=)" + _CONN_VALUE, re.IGNORECASE), r"\1[REDACTED:password]"),
+    # A connection URI carries its credential as scheme://user:pass@host. The
+    # whole user:pass is masked (a username can leak a service account, tenant,
+    # or topology) while scheme://, @host, port, and path stay verbatim -- the
+    # match ends at the @. The user/pass classes exclude URL structure chars so
+    # a match never crosses into host/port/query, and the negative lookahead on
+    # the marker keeps a second pass a no-op. scheme://host with no user:pass@
+    # (e.g. sb://ns/, http://localhost:7071/api) never matches.
+    (
+        re.compile(
+            r"([A-Za-z][A-Za-z0-9+.-]*://)"
+            r"(?!\[REDACTED:connection-credential\]@)"
+            r"[^\s\"',;{}\[\]/?#@:]+:[^@\s\"',;{}\[\]/?#]+@",
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:connection-credential]@",
+    ),
     (re.compile(r"(ClientSecret=)" + _CONN_VALUE, re.IGNORECASE), r"\1[REDACTED:client-secret]"),
     (
         re.compile(r"(?<![A-Za-z])(AccessKey=)" + _CONN_VALUE, re.IGNORECASE),

--- a/tests/test_parser_masking.py
+++ b/tests/test_parser_masking.py
@@ -97,6 +97,39 @@ def test_masks_each_secret_class():
         assert mask_text(raw) == expected, raw
 
 
+def test_masks_master_key():
+    cases = {
+        "MasterKey=abc123;X=y": "MasterKey=[REDACTED:function-key];X=y",
+        'MasterKey="abc123"': 'MasterKey="[REDACTED:function-key]"',
+    }
+    for raw, expected in cases.items():
+        assert mask_text(raw) == expected, raw
+
+
+def test_masks_connection_uri_userinfo():
+    cases = {
+        "amqp://user:secret@host": "amqp://[REDACTED:connection-credential]@host",
+        "postgresql://user:p4ssw0rd@host:5432/db": (
+            "postgresql://[REDACTED:connection-credential]@host:5432/db"
+        ),
+    }
+    for raw, expected in cases.items():
+        masked = mask_text(raw)
+        assert masked == expected, raw
+        assert "secret" not in masked
+        assert "p4ssw0rd" not in masked
+
+
+def test_connection_uri_without_userinfo_is_untouched():
+    cases = (
+        "sb://ns/",
+        "http://localhost:7071/api/hello",
+        "ftp://user@host",
+    )
+    for raw in cases:
+        assert mask_text(raw) == raw, raw
+
+
 def test_shared_access_key_name_is_not_masked():
     text = "Endpoint=sb://ns/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc"
     masked = mask_text(text)


### PR DESCRIPTION
## Summary
Closes #29. Two secret shapes inside §16's declared classes ("authorization headers, function keys, connection strings, and storage credentials") passed through `redact_secrets` unmasked:

- `MasterKey=<value>` — a function/master key
- `user:pass@host` userinfo in connection URIs (e.g. `postgresql://user:p4ssw0rd@host:5432/db`, `amqp://user:secret@host`)

## Changes
- **`MasterKey=`** → `[REDACTED:function-key]`, in the same class as the existing header/query function-key rules. Lookbehind prevents firing on a longer word ending in `MasterKey`; negative lookahead keeps a second pass idempotent.
- **Connection-URI userinfo** → `scheme://[REDACTED:connection-credential]@…`. The whole `user:pass` is masked (a username can leak a service account / tenant / topology); `scheme://`, `@host`, port, and path stay verbatim. Character classes exclude URL structure chars so a match never crosses into host/port/query.

## Verification
- New tests: `test_masks_master_key`, `test_masks_connection_uri_userinfo`, `test_connection_uri_without_userinfo_is_untouched`.
- Negative cases stay verbatim: `sb://ns/`, `http://localhost:7071/api/hello`, `ftp://user@host` (no password).
- Full suite: **122 passed**.