### PR TITLE
chore(packaging): single-source __version__ and remove dead HTTP-status regex (#35, #36)

### DIFF
--- a/src/funcviz/__init__.py
+++ b/src/funcviz/__init__.py
@@ -1,3 +1,10 @@
 """funcviz — turn Azure Functions verbose runtime logs into an execution timeline."""
 
-__version__ = "0.1.0.dev0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    # Read from distribution metadata so __version__ can never drift from the
+    # version declared in pyproject.toml (issue #35).
+    __version__ = version("funcviz")
+except PackageNotFoundError:  # pragma: no cover - uninstalled source checkout
+    __version__ = "0.0.0+unknown"

--- a/src/funcviz/parser/regexes.py
+++ b/src/funcviz/parser/regexes.py
@@ -27,7 +27,6 @@ _WORKER_INVOCATION = re.compile(
     r".*invocation ID: (?P<invocation>[0-9a-fA-F-]{36})"
 )
 _HTTP_REQUEST_ID = re.compile(r'"requestId":\s*"(?P<http>[0-9a-fA-F-]{36})"')
-_HTTP_STATUS = re.compile(r'"status":\s*"(?P<status>\d+)"')
 _HTTP_DURATION = re.compile(r'"duration":\s*"(?P<duration>\d+)"')
 
 _HTTP_REQUEST_START = "Executing HTTP request:"
@@ -102,11 +101,6 @@ def match_worker_invocation(content: str) -> dict[str, str] | None:
 def find_http_request_id(content: str) -> str | None:
     m = _HTTP_REQUEST_ID.search(content)
     return m.group("http") if m else None
-
-
-def find_http_status(content: str) -> str | None:
-    m = _HTTP_STATUS.search(content)
-    return m.group("status") if m else None
 
 
 def find_http_duration(content: str) -> str | None:


### PR DESCRIPTION
## Summary
Two small package-hygiene fixes, reviewed by Oracle (94/100, no blockers).

- **#35** — `funcviz.__version__` was hardcoded `0.1.0.dev0`, disagreeing with pyproject's `0.1.0`. Now derived from `importlib.metadata.version("funcviz")` so it can never drift, with a `0.0.0+unknown` fallback for uninstalled source checkouts.
- **#36** — Removed the unused `_HTTP_STATUS` regex and `find_http_status()` accessor (zero callers in `src/` or `tests/`; HTTP status is outside the v0.1 PRD FR-8 / trace-schema scope). `find_http_duration` is retained since it feeds the http-reported interval.

## Verification
- 122 tests pass, ruff clean, LSP diagnostics clean
- `import funcviz; funcviz.__version__` now returns `0.1.0`
- PRD R1 still holds: only `parser/regexes.py` imports `re`

Closes #35
Closes #36