### PR TITLE
fix(parser): mask SystemKey= + JSON master/system keys; capture-doc fixes (#38, #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,22 @@ engineers, SME presentations, and onboarding need.
 pip install funcviz
 
 # 1. Capture (you run this against your own Function App)
+#    The Python Worker lane only populates when the worker log categories are
+#    elevated in host.json (Microsoft.Azure.WebJobs.Script.Grpc / Worker /
+#    Host.Function.Console = "Trace") and PYTHON_ENABLE_DEBUG_LOGGING=1 is set.
+#    See PRD.md §5; examples/python-http-trigger/host.json already carries this.
 func start --verbose > run.log
 
-# 2. Parse logs into a trace
-funcviz parse run.log -o trace.json
+# 2. Parse logs into a trace, embedding the executed source for the source panel
+funcviz parse run.log -o trace.json --source path/to/function_app.py
 
 # 3. View the interactive timeline
 funcviz view trace.json
 ```
+
+Without the elevated log levels the Host and Client lanes still populate, but the Worker lane is
+reported as `unknown` — a legitimate lane status, not a parser bug. `--source` is optional and
+opt-in (it keeps the parser pure); omit it and the viewer's source panel shows a placeholder.
 
 Every event carries a `confidence` field (`observed` vs `inferred`) and its original log line, so a
 viewer who doubts the visualization can check it against the source text in one interaction.
@@ -50,15 +58,13 @@ lane is the `application` window (user-code entry/exit is not separately logged)
 
 ```
 examples/             # runnable demo Function App used for Phase 0
-samples/              # captured raw logs (parser fixtures)
+samples/              # captured raw logs (parser fixtures); see samples/README.md
 docs/event-coverage.md# Phase 0 evidence matrix (real log lines per event)
-PRD.md                # product requirements + decision log
-IDEAS.md              # deferred / uncommitted ideas
-
-# planned (created as v0.1 lands):
 src/funcviz/          # Python package: parser (pure) + CLI + static viewer
 schemas/              # trace JSON schema (versioned)
 traces/               # generated sample traces
+PRD.md                # product requirements + decision log
+IDEAS.md              # deferred / uncommitted ideas
 ```
 
 ## Scope (v0.1)

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,28 @@
+# Sample logs (parser fixtures)
+
+These raw `func start --verbose` logs are the parser's regression fixtures. Preserving the original
+runtime text is the PRD R1 mitigation: the golden traces in `../traces/` are regenerated from these,
+so a Core Tools log-format change surfaces here first.
+
+## Provenance
+
+| File | Origin | Trigger scenario |
+|---|---|---|
+| `success.log` | **Real capture** | Successful HTTP invocation of `hello` |
+| `worker-fail.log` | **Real capture** | Worker fails to index (`ModuleNotFoundError`) |
+| `invocation-fail.log` | ⚠️ **Synthetic** — hand-edited from `success.log` (`Succeeded`→`Failed`, `"status": "200"`→`"500"`) | In-invocation failure |
+| `worker-unobserved.log` | ⚠️ **Synthetic** — `success.log` with the worker-side lines removed | Worker lane unobservable (log levels not elevated) |
+
+## Why the synthetic ones are flagged
+
+PRD §7.2 ("do not simulate what is measurable") and acceptance criteria AC2–AC3 call for a **real**
+successful invocation and a **real** failure log. The two synthetic fixtures above assert the parser
+against an edited input, not against text a real runtime emitted — so their failure/unknown
+regression tests currently validate an assumption about the log shape rather than the shape itself.
+A real thrown exception, for instance, is likely to emit more than one `Executed ... (Failed, ...)`
+line (stack trace, `Exception while executing function`, worker-side error), which an edited success
+log cannot reveal.
+
+They are kept only as placeholders and must be replaced by real captures produced the same way as
+Phase 0 (capture → save here → record the real lines as evidence in `../docs/event-coverage.md`).
+Until then, treat any parser behavior that depends solely on these two files as unverified.

--- a/src/funcviz/parser/regexes.py
+++ b/src/funcviz/parser/regexes.py
@@ -202,13 +202,26 @@ _REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
         ),
         r"\1[REDACTED:function-key]",
     ),
-    # MasterKey=<value> is a function/master key in the same class as the
-    # header/query function-key rules above. The lookbehind stops it firing on
-    # a longer word ending in "MasterKey", and the negative lookahead makes a
-    # second pass a no-op (the marker is not re-captured as a value).
+    # Master/system keys emitted inside a folded JSON block ("masterKey": "..").
+    # Host logs carry keys in JSON as often as in query/equals form, so the same
+    # quoted-key handling as x-functions-key above is needed here; _HEADER_VALUE
+    # stops at the closing quote so a second pass re-captures only the marker.
     (
         re.compile(
-            r"((?<![A-Za-z])MasterKey=" + _Q + r")(?!\[REDACTED:function-key\])" + _CONN_VALUE,
+            r"(" + _Q + r"(?:master|system)Key" + _Q + r"\s*:\s*" + _Q + r")" + _HEADER_VALUE,
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED:function-key]",
+    ),
+    # MasterKey=/SystemKey=<value> are function keys in the same class as the
+    # header/query function-key rules above (SystemKey is used by the Durable
+    # and Event Grid extensions). The lookbehind stops it firing on a longer
+    # word ending in the key name, and the negative lookahead makes a second
+    # pass a no-op (the marker is not re-captured as a value).
+    (
+        re.compile(
+            r"((?<![A-Za-z])(?:Master|System)Key=" + _Q + r")"
+            r"(?!\[REDACTED:function-key\])" + _CONN_VALUE,
             re.IGNORECASE,
         ),
         r"\1[REDACTED:function-key]",

--- a/tests/test_parser_masking.py
+++ b/tests/test_parser_masking.py
@@ -101,9 +101,22 @@ def test_masks_master_key():
     cases = {
         "MasterKey=abc123;X=y": "MasterKey=[REDACTED:function-key];X=y",
         'MasterKey="abc123"': 'MasterKey="[REDACTED:function-key]"',
+        "SystemKey=abc123;X=y": "SystemKey=[REDACTED:function-key];X=y",
+        'SystemKey="abc123"': 'SystemKey="[REDACTED:function-key]"',
+        '"masterKey": "Zm9v"': '"masterKey": "[REDACTED:function-key]"',
+        '"systemKey": "Zm9v"': '"systemKey": "[REDACTED:function-key]"',
+        "'masterKey': 'Zm9v'": "'masterKey': '[REDACTED:function-key]'",
+        '"masterKey":"Zm9v"': '"masterKey":"[REDACTED:function-key]"',
+        '"systemKey":Zm9v': '"systemKey":[REDACTED:function-key]',
+        '"SystemKEY": "Zm9v"': '"SystemKEY": "[REDACTED:function-key]"',
     }
     for raw, expected in cases.items():
         assert mask_text(raw) == expected, raw
+
+
+def test_master_key_does_not_fire_on_longer_word():
+    text = "AzureWebJobsMasterKey=xyz"
+    assert mask_text(text) == text
 
 
 def test_masks_connection_uri_userinfo():


### PR DESCRIPTION
## Summary
Unblocked review follow-ups. Oracle-reviewed (94/100, no blockers).

### Masking (#38) — security
The §16 function-key class was leaking two forms (verified by running `redact_secrets()`):
- `SystemKey=…` (Durable / Event Grid extension key) — now `[REDACTED:function-key]`
- JSON-quoted `"masterKey": "…"` / `"systemKey": "…"` (folded-block shape) — now redacted

Extends the equals rule to `Master|System` and adds a JSON quoted-key rule modeled on the existing `x-functions-key` handling. Idempotent; key stays visible. Tests cover spaced/no-space/unquoted/mixed-case forms and the `AzureWebJobsMasterKey=` longer-word guard.

Nested admin key-bags (`functionKeys`/`systemKeys`) are outside v0.1's local-log input scope → deferred in #40.

### Docs (#39)
- README: host.json log-level + `PYTHON_ENABLE_DEBUG_LOGGING` capture prerequisite (PRD §5) and `--source` on the parse step; repository layout de-staled.
- New `samples/README.md`: marks `invocation-fail.log` and `worker-unobserved.log` as **synthetic** hand-edits of `success.log` (identical timestamps) pending real captures.

## Verification
- 123 tests pass, ruff clean, LSP clean
- PRD R1 holds: only `parser/regexes.py` imports `re`

## Out of scope (blocked on real captures)
Golden-trace regeneration with `--source`, `docs/event-coverage.md` evidence, and failure-path parser work await real `func start` captures.

Closes #38
Closes #39