### PR TITLE
fix(traces): embed executed source in golden success.json (AC6/AC10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,53 @@ opt-in (it keeps the parser pure); omit it and the viewer's source panel shows a
 Every event carries a `confidence` field (`observed` vs `inferred`) and its original log line, so a
 viewer who doubts the visualization can check it against the source text in one interaction.
 
+## Try it now (no capture required)
+
+The repo ships a real captured log, a demo Function App, and a ready-made trace, so you can
+reproduce the full pipeline end-to-end without running your own Function App. From a clone
+(`pip install -e .`, or run the module directly), the steps below produce exactly the outputs shown.
+
+```bash
+# Quickest path: view the trace that ships with the repo
+funcviz view traces/success.json
+```
+
+Expected: a local static server prints `funcviz viewer: http://127.0.0.1:<port>/index.html`
+(HTTP `200`), the page title is `funcviz — trace viewer`, and the **source panel is populated with
+`function_app.py`** — no placeholder. The committed `traces/success.json` embeds the executed source
+(`definitionLineRange` `[6, 9]`), so this works out of the box.
+
+To regenerate that trace yourself from the raw log:
+
+```bash
+# 1. Parse the bundled success log, embedding the executed source for the panel
+funcviz parse samples/success.log -o trace.json \
+    --source examples/python-http-trigger/function_app.py
+```
+
+Expected `trace.json` (verified): `outcome: success`, `7` events, and four lanes —
+`host` and `python-worker` are `observed`/reached, `client` and `application` are
+`inferred`/reached. The `application` block carries the embedded source:
+
+```jsonc
+"application": {
+  "sourceFile": "function_app.py",
+  "sourceText": "…",           // the executed function_app.py, embedded verbatim
+  "definitionLineRange": [6, 9] // the def hello(...) span
+}
+```
+
+`--source` is optional and opt-in (it keeps the parser pure); omit it and the same trace renders
+correctly but the viewer's source panel shows the "source not embedded" placeholder instead.
+
+```bash
+# Streaming variant: pipe a live run straight into a trace
+func start --verbose | funcviz record -o trace.json
+```
+
+`record` reads stdin until EOF/Ctrl-C and writes the same schema-0.1 trace (verified: `7` events
+from the bundled log).
+
 ## What's honest about it
 
 Phase 0 discovery (see [`docs/event-coverage.md`](docs/event-coverage.md)) confirmed against a real

--- a/tests/test_parser_contracts.py
+++ b/tests/test_parser_contracts.py
@@ -12,8 +12,10 @@ import json
 from pathlib import Path
 
 from funcviz.parser import from_log_text, mask_records, parse_trace
+from funcviz.source import enrich_trace_from_source
 
 ROOT = Path(__file__).resolve().parent.parent
+SOURCE = ROOT / "examples" / "python-http-trigger" / "function_app.py"
 HTTP_REQUEST_ID = "2d0db691-8e70-4335-a8a9-e127715fa678"
 WORKER_REQUEST_ID = "e42785bf-7670-4de1-a81d-b05df7b2b32d"
 INVOCATION_ID = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
@@ -21,7 +23,8 @@ INVOCATION_ID = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
 
 def _trace() -> dict[str, object]:
     text = (ROOT / "samples" / "success.log").read_text()
-    return parse_trace(mask_records(from_log_text(text)), trace_id="success-001").to_dict()
+    trace = parse_trace(mask_records(from_log_text(text)), trace_id="success-001")
+    return enrich_trace_from_source(trace, SOURCE).to_dict()
 
 
 def _events() -> list[dict[str, object]]:

--- a/tests/test_parser_success.py
+++ b/tests/test_parser_success.py
@@ -16,9 +16,11 @@ from jsonschema import Draft202012Validator
 
 from funcviz.models import LogRecord
 from funcviz.parser import from_log_text, mask_records, parse_trace
+from funcviz.source import enrich_trace_from_source
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
+SOURCE = ROOT / "examples" / "python-http-trigger" / "function_app.py"
 
 FROZEN_EVENTS = [
     "HttpRequestReceived",
@@ -33,7 +35,8 @@ FROZEN_EVENTS = [
 
 def _parsed() -> dict[str, object]:
     text = (ROOT / "samples" / "success.log").read_text()
-    return parse_trace(mask_records(from_log_text(text)), trace_id="success-001").to_dict()
+    trace = parse_trace(mask_records(from_log_text(text)), trace_id="success-001")
+    return enrich_trace_from_source(trace, SOURCE).to_dict()
 
 
 def test_success_log_validates_against_schema():
@@ -77,7 +80,8 @@ def test_multiline_http_block_is_folded_into_one_event():
 def test_bare_message_records_parse_without_from_log_text():
     text = (ROOT / "samples" / "success.log").read_text()
     bare = [LogRecord(message=line) for line in text.splitlines()]
-    assert parse_trace(mask_records(bare), trace_id="success-001").to_dict() == _parsed()
+    trace = parse_trace(mask_records(bare), trace_id="success-001")
+    assert enrich_trace_from_source(trace, SOURCE).to_dict() == _parsed()
 
 
 def test_structured_timestamp_is_honored_over_message_prefix():

--- a/traces/success.json
+++ b/traces/success.json
@@ -16,7 +16,12 @@
   },
   "application": {
     "functionName": "hello",
-    "sourceFile": "function_app.py"
+    "sourceFile": "function_app.py",
+    "sourceText": "import azure.functions as func\n\napp = func.FunctionApp()\n\n\n@app.route(route=\"hello\")\ndef hello(req: func.HttpRequest) -> func.HttpResponse:\n    name = req.params.get(\"name\") or \"Azure\"\n    return func.HttpResponse(f\"Hello, {name}!\")\n",
+    "definitionLineRange": [
+      6,
+      9
+    ]
   },
   "lanes": {
     "client": {


### PR DESCRIPTION
## Summary
- Regenerate `traces/success.json` **with** `--source examples/python-http-trigger/function_app.py`, so the shipped golden embeds `sourceText` + `definitionLineRange [6,9]`. Fixes the AC6/AC10 gap where `funcviz view traces/success.json` showed the source-panel placeholder.
- Update byte-compare helpers (`test_parser_success.py`, `test_parser_contracts.py`) to enrich identically, keeping goldens green.
- Add a verified **"Try it now (no capture required)"** walkthrough to the README.

## Why now (unblocked)
`samples/success.log` is a real capture, so this needed no new capture. Only the synthetic fixtures (`invocation-fail`, `worker-unobserved`) remain, blocked on real captures in #43. `worker-fail.json` is correctly `application: None` (worker crashed before any function loaded) and is not an AC6 defect.

## Verification
- `pytest`: 123 passed. `ruff`: clean.
- Headless render of committed `traces/success.json`: `placeholderShown: false`, source panel shows `function_app.py`, HTTP 200, 0 console errors.

Progresses #42.