### PR TITLE
fix(traces): embed executed source in invocation-fail; honest unknown-lane source panel (#45)

### DIFF
--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -1055,9 +1055,16 @@
       }
     } else {
       ph = el("div", "source-placeholder");
-      ph.appendChild(tx("Source text was not embedded in this trace. "));
-      ph.appendChild(el("code", null, app.sourceFile || "the source file"));
-      ph.appendChild(tx(" was recorded as the source file, but local file loading is unavailable from file://."));
+      if (status === "unknown") {
+        ph.appendChild(tx("Application execution was not observed, so the source of "));
+        ph.appendChild(el("code", null, app.sourceFile || "the source file"));
+        ph.appendChild(tx(" is not embedded — showing it here would imply this code ran. " +
+          "Re-run with elevated worker logging (see host.json) to observe the worker/application lanes."));
+      } else {
+        ph.appendChild(tx("Source text was not embedded in this trace. "));
+        ph.appendChild(el("code", null, app.sourceFile || "the source file"));
+        ph.appendChild(tx(" was recorded as the source file, but local file loading is unavailable from file://."));
+      }
       body.appendChild(ph);
     }
     panel.appendChild(body);

--- a/tests/test_parser_invocation_fail.py
+++ b/tests/test_parser_invocation_fail.py
@@ -18,9 +18,11 @@ from pathlib import Path
 from jsonschema import Draft202012Validator
 
 from funcviz.parser import from_log_text, mask_records, parse_trace
+from funcviz.source import enrich_trace_from_source
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = json.loads((ROOT / "schemas" / "trace-0.1.json").read_text())
+SOURCE = ROOT / "examples" / "python-http-trigger" / "function_app.py"
 
 INVOCATION_FAIL_EVENTS = [
     "HttpRequestReceived",
@@ -34,7 +36,8 @@ INVOCATION_FAIL_EVENTS = [
 
 def _parsed() -> dict[str, object]:
     text = (ROOT / "samples" / "invocation-fail.log").read_text()
-    return parse_trace(mask_records(from_log_text(text)), trace_id="invocation-fail-001").to_dict()
+    trace = parse_trace(mask_records(from_log_text(text)), trace_id="invocation-fail-001")
+    return enrich_trace_from_source(trace, SOURCE).to_dict()
 
 
 def test_invocation_fail_log_validates_against_schema():

--- a/traces/invocation-fail.json
+++ b/traces/invocation-fail.json
@@ -16,7 +16,12 @@
   },
   "application": {
     "functionName": "hello",
-    "sourceFile": "function_app.py"
+    "sourceFile": "function_app.py",
+    "sourceText": "import azure.functions as func\n\napp = func.FunctionApp()\n\n\n@app.route(route=\"hello\")\ndef hello(req: func.HttpRequest) -> func.HttpResponse:\n    name = req.params.get(\"name\") or \"Azure\"\n    return func.HttpResponse(f\"Hello, {name}!\")\n",
+    "definitionLineRange": [
+      6,
+      9
+    ]
   },
   "lanes": {
     "client": {


### PR DESCRIPTION
## Summary
- Regenerate `traces/invocation-fail.json` with the executed source embedded (`sourceText` + `definitionLineRange [6,9]`) — its `application` lane is `reached` (the body ran, then failed), so showing the source is honest (AC6).
- Leave `worker-unobserved.json` unembedded by design: its `application` lane is `unknown` (worker delivery never observed), so embedding executed source would overclaim per PRD §7.2 — mirroring `worker-fail.json`. Confirmed by Oracle.
- Viewer: the source panel now shows a distinct message when the application lane is `unknown` ("Application execution was not observed … showing it here would imply this code ran"), separate from the generic "not embedded / file:// unavailable" placeholder.
- Enrich the `invocation-fail` byte-compare test helper to match the regenerated golden.

## Verification
- 123 tests pass, ruff clean, R1 holds (only `regexes.py` imports `re`).
- Headless: invocation-fail → panel populated with `def hello` (no placeholder); worker-unobserved → distinct unknown-lane message, no source leaked; 0 console errors on both.

Closes #45. Out of scope: #43 (real captures for AC2/AC3, blocked on user-provided logs).