### PR TITLE
chore(traces): pin golden regeneration in script + Makefile (#47)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+PYTHON ?= python3
+
+.PHONY: traces traces-check
+
+traces:
+	$(PYTHON) scripts/regen_traces.py
+
+traces-check:
+	$(PYTHON) scripts/regen_traces.py --check

--- a/scripts/regen_traces.py
+++ b/scripts/regen_traces.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Canonical regenerator for the committed golden traces (AC6/AC10 durability).
+
+Each golden trace under ``traces/`` is produced by exactly one ``funcviz parse``
+invocation. Encoding those invocations here — rather than in a README a human
+must remember to follow — means a future trace change cannot silently drop the
+embedded source or use the wrong ``--trace-id``.
+
+Honesty rule (PRD §7.2): only traces whose ``application`` lane actually reaches
+user-code embed ``--source``. ``worker-unobserved`` (application=unknown) and
+``worker-fail`` (no application block) must *not* embed source.
+
+Regeneration drives the real :func:`funcviz.cli.main` ``parse`` code path with
+``-o -`` so the bytes are identical to what ``funcviz parse`` writes; the script
+never reimplements the parse/enrich/serialize pipeline.
+
+Usage::
+
+    python scripts/regen_traces.py           # rewrite traces/*.json in place
+    python scripts/regen_traces.py --check    # fail if any trace is stale
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from funcviz import cli  # noqa: E402  (path set up above)
+
+SAMPLES = ROOT / "samples"
+TRACES = ROOT / "traces"
+SOURCE = ROOT / "examples" / "python-http-trigger" / "function_app.py"
+
+
+@dataclass(frozen=True)
+class Golden:
+    """One committed golden trace and how to regenerate it."""
+
+    stem: str
+    trace_id: str
+    source: bool  # embed --source (only when application reaches user code)
+
+    @property
+    def log_path(self) -> Path:
+        return SAMPLES / f"{self.stem}.log"
+
+    @property
+    def trace_path(self) -> Path:
+        return TRACES / f"{self.stem}.json"
+
+
+GOLDENS: tuple[Golden, ...] = (
+    Golden("success", "success-001", source=True),
+    Golden("invocation-fail", "invocation-fail-001", source=True),
+    Golden("worker-unobserved", "worker-unobserved-001", source=False),
+    Golden("worker-fail", "worker-fail-001", source=False),
+)
+
+
+def render(golden: Golden) -> str:
+    """Return the canonical JSON text for ``golden`` via the real CLI path."""
+    argv = ["parse", str(golden.log_path), "-o", "-", "--trace-id", golden.trace_id]
+    if golden.source:
+        argv += ["--source", str(SOURCE)]
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = cli.main(
+        argv,
+        stdin=io.StringIO(""),
+        stdout=stdout,
+        stderr=stderr,
+        opener=lambda _url: None,
+    )
+    if code != 0:
+        raise RuntimeError(f"funcviz parse failed for {golden.stem}: {stderr.getvalue()}")
+    return stdout.getvalue()
+
+
+def _write(golden: Golden) -> None:
+    golden.trace_path.write_text(render(golden), encoding="utf-8")
+
+
+def _check(golden: Golden) -> bool:
+    """Return True when the committed trace matches a fresh render."""
+    expected = render(golden)
+    try:
+        actual = golden.trace_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return actual == expected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify committed traces are up to date instead of rewriting them",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        stale = [g.stem for g in GOLDENS if not _check(g)]
+        if stale:
+            print("stale golden traces (run `make traces`): " + ", ".join(stale))
+            return 1
+        print(f"all {len(GOLDENS)} golden traces up to date")
+        return 0
+
+    for golden in GOLDENS:
+        _write(golden)
+    print(f"regenerated {len(GOLDENS)} golden traces")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_regen_traces.py
+++ b/tests/test_regen_traces.py
@@ -1,0 +1,57 @@
+"""Golden-trace regeneration is idempotent and honesty-preserving (issue #47)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.regen_traces import GOLDENS, main, render  # noqa: E402  (needs sys.path setup)
+
+EXPECTED_TRACE_IDS = {
+    "success": "success-001",
+    "invocation-fail": "invocation-fail-001",
+    "worker-unobserved": "worker-unobserved-001",
+    "worker-fail": "worker-fail-001",
+}
+
+
+@pytest.mark.parametrize("golden", GOLDENS, ids=lambda g: g.stem)
+def test_render_matches_committed_trace(golden):
+    assert render(golden) == golden.trace_path.read_text(encoding="utf-8")
+
+
+def test_check_mode_passes_for_committed_traces():
+    assert main(["--check"]) == 0
+
+
+@pytest.mark.parametrize("golden", GOLDENS, ids=lambda g: g.stem)
+def test_rendered_trace_id_is_pinned(golden):
+    expected = EXPECTED_TRACE_IDS[golden.stem]
+    assert golden.trace_id == expected
+    assert json.loads(render(golden))["traceId"] == expected
+
+
+def _has_embedded_source(rendered: dict) -> bool:
+    application = rendered.get("application")
+    return bool(application) and application.get("sourceText") is not None
+
+
+@pytest.mark.parametrize("golden", GOLDENS, ids=lambda g: g.stem)
+def test_rendered_source_embed_matches_honesty_rule(golden):
+    rendered = json.loads(render(golden))
+    assert _has_embedded_source(rendered) is golden.source
+
+
+def test_dropping_source_flag_is_caught_against_committed_trace():
+    success = next(g for g in GOLDENS if g.stem == "success")
+    stripped = render(replace(success, source=False))
+    assert stripped != success.trace_path.read_text(encoding="utf-8")
+    assert _has_embedded_source(json.loads(stripped)) is False


### PR DESCRIPTION
## Summary
- Adds `scripts/regen_traces.py`, a canonical regenerator that drives the real `funcviz.cli` `parse` path (`-o -`) so output is byte-identical to `funcviz parse` — no serializer reimplementation drift.
- Encodes the two durability invariants behind AC6/AC10 so they cannot silently regress:
  - each golden trace is pinned to its explicit `--trace-id` (`<stem>-001`, which the CLI would otherwise derive from the filename stem),
  - `--source` is embedded **only** for application-reached traces (`success`, `invocation-fail`); `worker-unobserved` (application=unknown, PRD §7.2) and `worker-fail` (no application block) embed nothing.
- `Makefile` exposes `make traces` (rewrite in place) and `make traces-check` (`--check` fails CI on any stale trace). `PYTHON ?= python3`; the script self-inserts `src/` on `sys.path`, so it runs without `PYTHONPATH`.

## Tests (137 pass, was 129)
- Byte-for-byte idempotency per golden + `--check` mode.
- Independent oracles against **rendered JSON**: pinned trace-ids (literal expected map) and source-embed honesty (`sourceText` present iff the trace reaches user code).
- Regression guard: rendering `success` with `--source` dropped diverges from the committed trace and carries no embedded source.

## Verification
- `make traces` → zero `git diff` on `traces/`; `make traces-check` passes.
- ruff clean; R1 invariant intact (only `parser/regexes.py` imports `re`).
- Oracle review: 92/100.

Closes #47.