### PR TITLE
ci: wire make traces-check into CI + regen script cleanups (#81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: ruff check src/ tests/
       - run: pytest -q
+      - run: make traces-check
 
   build:
     runs-on: ubuntu-latest

--- a/scripts/regen_traces.py
+++ b/scripts/regen_traces.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 SRC = ROOT / "src"
+# Allows running from a source checkout without `pip install -e .` (CI installs
+# the package, so the insert is a no-op there — sys.path already contains it).
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
@@ -99,7 +101,9 @@ def _check(golden: Golden) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description="Regenerate the committed golden traces via the real CLI path."
+    )
     parser.add_argument(
         "--check",
         action="store_true",


### PR DESCRIPTION
## Summary
- test job now runs `make traces-check` after pytest, making golden-trace drift a direct CI failure instead of an indirect dependency on one pytest test's name
- regen_traces.py: sys.path shim documented (run-without-install intent), argparse --help no longer dumps the RST docstring

## Verification
- 141 tests passed; Ruff clean; `make traces-check` green on current goldens
- stale-golden drill: corrupted traceId → check exits 1 with `stale golden traces (run make traces): success`; restored → exit 0
- ci.yml parses as valid YAML; this PR's own CI run executes the new step, proving the wiring

Closes #81