### PR TITLE
feat: incomplete-trace guard — partial captures never read as success (#84)

### DIFF
--- a/src/funcviz/parser/core.py
+++ b/src/funcviz/parser/core.py
@@ -63,6 +63,7 @@ def parse_trace(
     meta = _scan_metadata(folded)
     completed = next((r for r in raw_events if r["event"] == "InvocationCompleted"), None)
     resolved_outcome = _resolve_outcome(completed, raw_events, outcome)
+    incomplete = not _has_terminal_evidence(completed, raw_events)
 
     return Trace(
         trace_id=trace_id,
@@ -80,7 +81,24 @@ def parse_trace(
         intervals=intervals,
         application=_application_from(meta),
         failures=failures,
+        metadata={"incomplete": True} if incomplete else {},
     )
+
+
+def _has_terminal_evidence(
+    completed: dict[str, object] | None,
+    raw_events: list[dict[str, object]],
+) -> bool:
+    """Whether the log shows the run terminating (#84).
+
+    Terminal evidence: an ``InvocationCompleted`` record, or a worker indexing
+    failure. Without either, the capture ended before the run finished — the
+    resolved outcome is a fallback, so the trace must be marked incomplete
+    instead of silently reading as a completed success.
+    """
+    if completed is not None:
+        return True
+    return any(r["event"] == "WorkerIndexingFailed" for r in raw_events)
 
 
 def _resolve_outcome(

--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -100,6 +100,7 @@
   }
   .outcome-dot.outcome--success { background: var(--ok); }
   .outcome-dot.outcome--failure { background: var(--fail); }
+  .outcome-dot.outcome--incomplete { background: var(--worker); }
 
   /* ============================================================
      outcome chip (#55, spec §2.1) — the run outcome as a headline
@@ -116,6 +117,8 @@
   .outcome-chip .outcome-dot { margin: 0 7px 0 2px; }
   .outcome-chip[data-outcome="success"] { color: var(--ok); border-color: rgba(63,185,80,.45); background: rgba(63,185,80,.08); }
   .outcome-chip[data-outcome="failed"] { color: var(--fail); border-color: rgba(248,81,73,.5); background: rgba(248,81,73,.08); }
+  /* #84 — capture ended with no terminal evidence: never styled as clean success */
+  .outcome-chip[data-outcome="incomplete"] { color: var(--worker); border-color: rgba(227,179,65,.45); background: rgba(227,179,65,.08); }
   /* §2.1 — failure time in the summary line is subordinate, never the lead */
   .fail-at { color: var(--text-faint); font-weight: 400; font-size: 13px; }
   .runtime-meta {
@@ -446,6 +449,7 @@
   .outcome-rail-value { font-size: 13px; font-weight: 700; color: var(--text); }
   .outcome-rail-value--success { color: var(--ok); }
   .outcome-rail-value--failed { color: var(--fail); }
+  .outcome-rail-value--incomplete { color: var(--worker); }
   .outcome-rail-value--pending { color: var(--idle); font-weight: 600; }
   .outcome-rail-lane { font-size: 11.5px; color: var(--text-dim); }
   .outcome-rail-at { font-size: 11px; color: var(--text-faint); }
@@ -1397,16 +1401,29 @@
       summary.appendChild(tx(" · "));
       summary.appendChild(el("span", "dur", hostReported.durationMs + "ms"));
     }
-    /* §11.11 (#62) — the one-row header ellipsizes this line; the title
-       keeps the full summary reachable on hover/focus */
-    summary.parentElement.setAttribute("title", summary.textContent);
 
-    /* outcome chip — the run outcome as a band-A headline element (#55) */
+    /* outcome chip — the run outcome as a band-A headline element (#55).
+       #84: metadata.incomplete outranks the resolved outcome — a capture
+       that ended with no terminal evidence must never read as clean
+       success, whatever the fallback outcome was. */
+    var incomplete = !!(trace && trace.metadata && trace.metadata.incomplete);
+    var chipState = incomplete ? "incomplete"
+      : outcome === "success" ? "success"
+      : outcome === "failure" ? "failed" : "none";
+    var chipLabel = incomplete ? "incomplete"
+      : outcome === "success" ? "success"
+      : outcome === "failure" ? "failed" : outcome;
     chip.textContent = "";
-    chip.setAttribute("data-outcome",
-      outcome === "success" ? "success" : outcome === "failure" ? "failed" : "none");
-    chip.appendChild(el("span", "outcome-dot outcome--" + outcome));
-    chip.appendChild(tx(outcome === "success" ? "success" : outcome === "failure" ? "failed" : outcome));
+    chip.setAttribute("data-outcome", chipState);
+    chip.appendChild(el("span", "outcome-dot outcome--" + (incomplete ? "incomplete" : outcome)));
+    chip.appendChild(tx(chipLabel));
+    if (incomplete) {
+      summary.appendChild(tx(" · "));
+      summary.appendChild(el("span", "fail-at", "capture ended before the run finished"));
+    }
+    /* §11.11 (#62) — the one-row header ellipsizes this line; the title
+       keeps the full summary (incl. the #84 incomplete suffix) reachable */
+    summary.parentElement.setAttribute("title", summary.textContent);
 
     var rt = (trace && trace.runtime) || {};
     var parts = [];
@@ -2459,6 +2476,16 @@
         "Pre-play — the recorded outcome is in the header and is stated here on replay."));
       return rail;
     }
+    /* #84 — an incomplete capture outranks the resolved outcome here too:
+       the rail must never state "✓ success" for a run that never finished */
+    if (trace && trace.metadata && trace.metadata.incomplete) {
+      rail.setAttribute("data-state", "incomplete");
+      rail.appendChild(el("span", "outcome-rail-value outcome-rail-value--incomplete",
+        "◦ incomplete"));
+      rail.appendChild(el("span", "outcome-rail-note",
+        "Capture ended before the run's terminal event — no outcome was observed."));
+      return rail;
+    }
     if (outcome === "failure") {
       rail.setAttribute("data-state", "failed");
       rail.appendChild(el("span", "outcome-rail-value outcome-rail-value--failed", "⨯ failed"));
@@ -2760,6 +2787,8 @@
     title.setAttribute("id", "errorSummaryTitle");
     panel.appendChild(title);
     viewport = el("div", "error-viewport");
+    panel.setAttribute("data-incomplete",
+      trace && trace.metadata && trace.metadata.incomplete ? "true" : "false");
 
     if (!failure) {
       /* outcome=failure with no structured failure record must not read as
@@ -2778,9 +2807,16 @@
       panel.setAttribute("data-failure-kind", "");
       panel.setAttribute("data-failure-lane", "");
       panel.setAttribute("data-error-message", "");
-      viewport.appendChild(el("p", "error-empty-row", trace
-        ? "No errors — the run completed."
-        : "No trace loaded."));
+      /* #84 — an incomplete capture is not an error, but it must not read
+         as a completed clean run either */
+      if (trace && trace.metadata && trace.metadata.incomplete) {
+        viewport.appendChild(el("p", "error-empty-row",
+          "Run incomplete — capture ended before the run's terminal event."));
+      } else {
+        viewport.appendChild(el("p", "error-empty-row", trace
+          ? "No errors — the run completed."
+          : "No trace loaded."));
+      }
       panel.appendChild(viewport);
       return;
     }
@@ -3440,7 +3476,7 @@
     }
     renderTrace(res.trace);
     setStatus("Loaded " + label + " — " + res.trace.events.length + " events, outcome: " +
-      (res.trace.outcome || "?") + ".", "ok");
+      _outcomeLabel(res.trace) + ".", "ok");
     return true;
   }
 
@@ -3453,8 +3489,14 @@
     }
     renderTrace(res.trace);
     var summary = "Showing embedded trace (" + (res.trace.traceId || "unknown") + ") — " +
-      res.trace.events.length + " events, outcome: " + (res.trace.outcome || "?") + ".";
+      res.trace.events.length + " events, outcome: " + _outcomeLabel(res.trace) + ".";
     setStatus(quiet ? summary : "Restored default trace — " + summary, "ok");
+  }
+
+  /* #84 — status lines must not report a fallback outcome as observed fact */
+  function _outcomeLabel(trace) {
+    if (trace && trace.metadata && trace.metadata.incomplete) return "incomplete (capture ended early)";
+    return trace.outcome || "?";
   }
 
   /* ---------------- wiring ----------------------------------------------- */

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,3 +145,35 @@ def test_record_writes_partial_on_keyboard_interrupt(tmp_path):
     assert code == 0
     assert json.loads(out.read_text())["schemaVersion"] == "0.1"
     assert "interrupted" in stderr.getvalue()
+
+
+def test_record_partial_without_terminal_event_is_marked_incomplete(tmp_path):
+    """#84 — a Ctrl-C partial capture must not read as a completed success."""
+    out = tmp_path / "trace.json"
+    text = SUCCESS_LOG.read_text()
+    tailless = (
+        "\n".join(line for line in text.splitlines() if "Executed 'Functions." not in line) + "\n"
+    )
+
+    class InterruptingStdin:
+        def __init__(self, payload):
+            self._payload = payload
+            self._served = False
+
+        def read(self, _size=-1):
+            if not self._served:
+                self._served = True
+                return self._payload
+            raise KeyboardInterrupt
+
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = cli.main(
+        ["record", "-o", str(out)],
+        stdin=InterruptingStdin(tailless),
+        stdout=stdout,
+        stderr=stderr,
+        opener=lambda url: None,
+    )
+    assert code == 0
+    trace = json.loads(out.read_text())
+    assert trace["metadata"]["incomplete"] is True

--- a/tests/test_parser_contracts.py
+++ b/tests/test_parser_contracts.py
@@ -169,3 +169,37 @@ def test_elapsed_is_non_negative_and_monotonic():
 def test_golden_is_the_end_to_end_contract():
     golden = json.loads((ROOT / "traces" / "success.json").read_text())
     assert _trace() == golden
+
+
+def test_tailless_log_is_marked_incomplete_not_clean_success(tmp_path):
+    """#84 — a capture without terminal evidence must never read as completed."""
+    text = (ROOT / "samples" / "success.log").read_text()
+    tailless = (
+        "\n".join(line for line in text.splitlines() if "Executed 'Functions." not in line) + "\n"
+    )
+    assert "InvocationCompleted" not in {e["event"] for e in _events_from_text(tailless)}
+    trace = parse_trace(mask_records(from_log_text(tailless)), trace_id="tailless-001")
+    assert trace.metadata.get("incomplete") is True
+    out = trace.to_dict()
+    assert out["metadata"]["incomplete"] is True
+
+
+def test_completed_run_is_not_marked_incomplete():
+    text = (ROOT / "samples" / "success.log").read_text()
+    trace = parse_trace(mask_records(from_log_text(text)), trace_id="success-001")
+    assert not trace.metadata.get("incomplete")
+    assert "metadata" not in trace.to_dict()
+
+
+def test_indexing_failure_is_terminal_not_incomplete():
+    text = (ROOT / "samples" / "worker-fail.log").read_text()
+    trace = parse_trace(mask_records(from_log_text(text)), trace_id="worker-fail-001")
+    assert not trace.metadata.get("incomplete")
+
+
+def _events_from_text(text: str) -> list[dict[str, object]]:
+    from funcviz.parser.derive import synthesize_application_events
+    from funcviz.parser.events import extract_events
+    from funcviz.parser.records import fold_http_blocks
+
+    return synthesize_application_events(extract_events(fold_http_blocks(from_log_text(text))))


### PR DESCRIPTION
## Summary
- parser sets `metadata.incomplete: true` when a log has no terminal evidence (no InvocationCompleted and no WorkerIndexingFailed), so Ctrl-C partials and tail-less captures stop resolving to clean success
- no schema change: metadata is the free-form extension point, emitted only when non-empty — goldens stay byte-identical
- viewer: `incomplete` outranks the resolved outcome on every outcome surface — amber header chip, `◦ incomplete` outcome rail, honest error row, and load-status text "incomplete (capture ended early)"

## Verification
- 145 tests passed (4 new: tail-less log, completed log, indexing-failure-is-terminal, record interrupt)
- traces-check green (goldens byte-identical); Ruff and LSP clean
- end-to-end headless: tail-less parse → incomplete chip/rail/error row/status with no ✓ success anywhere; success and failure goldens unchanged
- Oracle 96/100 (blocker on the outcome rail found at 86, fixed and re-verified)

Closes #84