### PR TITLE
feat(parser): enforce single-invocation contract (#85)

### DIFF
--- a/src/funcviz/parser/core.py
+++ b/src/funcviz/parser/core.py
@@ -55,6 +55,7 @@ def parse_trace(
 ) -> Trace:
     folded = fold_http_blocks(log_records)
     raw_events = synthesize_application_events(extract_events(folded))
+    _enforce_single_invocation(raw_events)
     finalized = finalize_events(raw_events)
     intervals = build_intervals(finalized, raw_events)
     lanes = build_lanes(finalized, raw_events)
@@ -83,6 +84,24 @@ def parse_trace(
         failures=failures,
         metadata={"incomplete": True} if incomplete else {},
     )
+
+
+def _enforce_single_invocation(raw_events: list[dict[str, object]]) -> None:
+    """Reject multi-invocation input explicitly (#85, PRD v0.1 contract).
+
+    The parser's derivations (``next``-based event pairing, one interval set,
+    one lane lifecycle) silently assume exactly one invocation per log. Two
+    invocations in one capture would produce a plausible-but-wrong trace, so
+    the contract is enforced instead of assumed: more than one distinct
+    invocation id is a hard error. Zero ids is valid (worker-startup failure
+    logs never reach an invocation).
+    """
+    ids = sorted({str(r["invocationId"]) for r in raw_events if r.get("invocationId")})
+    if len(ids) > 1:
+        raise ValueError(
+            f"log contains {len(ids)} invocations ({', '.join(ids)}); "
+            "funcviz v0.1 traces exactly one invocation — capture one invocation per trace"
+        )
 
 
 def _has_terminal_evidence(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,3 +177,23 @@ def test_record_partial_without_terminal_event_is_marked_incomplete(tmp_path):
     assert code == 0
     trace = json.loads(out.read_text())
     assert trace["metadata"]["incomplete"] is True
+
+
+def test_parse_multi_invocation_log_fails_with_clear_message(tmp_path):
+    """#85 — the CLI surfaces the contract breach and writes nothing."""
+    import uuid
+
+    text = SUCCESS_LOG.read_text()
+    original = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
+    replacement = str(uuid.uuid4())
+    combined = text + "\n" + text.replace(original, replacement)
+    log = tmp_path / "multi.log"
+    log.write_text(combined)
+    out = tmp_path / "trace.json"
+
+    code, _, stderr = _run(["parse", str(log), "-o", str(out)])
+    assert code == 1
+    assert "funcviz:" in stderr
+    assert "2 invocations" in stderr
+    assert "one invocation per trace" in stderr
+    assert not out.exists()

--- a/tests/test_parser_contracts.py
+++ b/tests/test_parser_contracts.py
@@ -203,3 +203,24 @@ def _events_from_text(text: str) -> list[dict[str, object]]:
     from funcviz.parser.records import fold_http_blocks
 
     return synthesize_application_events(extract_events(fold_http_blocks(from_log_text(text))))
+
+
+def test_multi_invocation_log_is_rejected_explicitly():
+    """#85 — two invocations in one log must error, not silently mix."""
+    import pytest
+
+    text = (ROOT / "samples" / "success.log").read_text()
+    second = text.replace(
+        "6a8f3658-2b31-4554-aa86-1ee32a9e679b",
+        "7b1e4769-3c42-5b55-cc97-2ff43b0f780c",
+    )
+    combined = text + "\n" + second
+    with pytest.raises(ValueError, match=r"2 invocations.*one invocation per trace"):
+        parse_trace(mask_records(from_log_text(combined)), trace_id="multi-001")
+
+
+def test_zero_invocation_worker_startup_log_still_parses():
+    """#85 — worker-fail logs reach no invocation; that stays valid."""
+    text = (ROOT / "samples" / "worker-fail.log").read_text()
+    trace = parse_trace(mask_records(from_log_text(text)), trace_id="worker-fail-001")
+    assert trace.outcome.value == "failure"


### PR DESCRIPTION
## Summary
- parse_trace rejects input carrying more than one distinct invocation id before any derivation runs, erroring with the count, the ids, and the v0.1 remedy (one invocation per trace)
- zero-invocation worker-startup logs remain valid; the record path inherits the same guard
- same-id duplicated blocks remain allowed for v0.1 (duplicate/dedup policy is a separate concern — noted for a future issue if it proves confusing)

## Verification
- 148 tests passed (3 new: parser rejection, zero-invocation validity, CLI end-to-end exit 1 + no output file)
- traces-check green (goldens byte-identical); Ruff and LSP clean
- Oracle 94/100, no blockers

Closes #85