### PR TITLE
feat: --from-appinsights adapter — query-result JSON → trace (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ opt-in (it keeps the parser pure); omit it and the viewer's source panel shows a
 Every event carries a `confidence` field (`observed` vs `inferred`) and its original log line, so a
 viewer who doubts the visualization can check it against the source text in one interaction.
 
+### Production logs via App Insights export
+
+For a deployed app, export a query result and parse it the same way — `funcviz` stays an offline
+parser with no auth, SDK, or connector:
+
+```bash
+az monitor app-insights query --app <component> -g <rg> \
+  --analytics-query "union traces, requests | where operation_Id == '<op-id>' | project timestamp, itemType, message, name, customDimensions | order by timestamp asc" \
+  -o json > prod.json
+funcviz parse prod.json --from-appinsights -o trace.json
+```
+
+App Insights ingests the host bookends but not the raw python-worker verbose lines, so the worker
+lane is honestly `unknown` in traces built from an export; the client lane is absent by design.
+Latency aggregation and performance analytics stay in App Insights (see
+[`PRD.md`](PRD.md) §3.1) — a funcviz trace never becomes a dashboard.
+
 ## Try it now (no capture required)
 
 The repo ships a real captured log, a demo Function App, and a ready-made trace, so you can

--- a/src/funcviz/appinsights.py
+++ b/src/funcviz/appinsights.py
@@ -1,0 +1,151 @@
+"""App Insights query-result adapter (issue #67, PRD §5.1).
+
+Turns the JSON output of ``az monitor app-insights query`` into the same
+:class:`LogRecord` stream ``from_log_text`` produces, so the pure parser runs
+with zero edits (FR-2). Per the discovery in issue #66:
+
+- ``message`` carries the host log strings (Executing/Executed bookends), so
+  the v0.1 event-mapping regexes transfer as-is;
+- ``timestamp`` orders rows globally (the adapter sorts defensively even
+  though the reference query orders ascending);
+- raw python-worker verbose lines are NOT ingested by App Insights, so a
+  trace built from an export legitimately lacks worker-internal detail — the
+  parser's lane derivation already reports that honestly as ``unknown``.
+
+The adapter stays offline: it reads a file the user exported; it performs no
+auth, no network calls, and no Azure SDK dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from datetime import datetime, timezone
+
+from .models import LogRecord, Trace, TraceInput
+
+_SOURCE = "app-insights-query"
+_ADAPTER = "AppInsightsQueryAdapter"
+_ADAPTER_VERSION = "0.1"
+
+
+def records_from_query_result(data: Mapping[str, object]) -> list[LogRecord]:
+    """Flatten ``az monitor app-insights query -o json`` output to records.
+
+    Expected shape: ``{"tables": [{"columns": [{"name": ...}, ...],
+    "rows": [[...], ...]}]}`` with the reference projection from PRD §5.1
+    (``timestamp, itemType, message, name, customDimensions``). Rows without
+    a message cannot match any event mapping and are dropped.
+    """
+    tables = data.get("tables")
+    if not isinstance(tables, Sequence) or isinstance(tables, (str, bytes)):
+        raise ValueError(
+            "App Insights export has no 'tables' array (expected az CLI -o json output)"
+        )
+    records: list[LogRecord] = []
+    for table in tables:
+        if not isinstance(table, Mapping):
+            continue
+        columns = table.get("columns")
+        rows = table.get("rows")
+        if not isinstance(columns, Sequence) or not isinstance(rows, Sequence):
+            continue
+        names: list[str | None] = []
+        for c in columns:
+            name = c.get("name") if isinstance(c, Mapping) else None
+            names.append(name if isinstance(name, str) else None)
+        index: dict[str, int] = {name: i for i, name in enumerate(names) if name}
+        for row in rows:
+            if not isinstance(row, Sequence) or isinstance(row, (str, bytes)):
+                continue
+            ts = _cell(row, index, "timestamp")
+            message = _cell(row, index, "message")
+            if not isinstance(message, str) or not message.strip():
+                continue
+            if not isinstance(ts, str) or not ts.strip():
+                raise ValueError(
+                    "App Insights export has a message-bearing row without a timestamp; "
+                    "the reference query must project timestamp"
+                )
+            ts_text = _normalize_timestamp(ts)
+            content = message
+            records.append(
+                LogRecord(
+                    message=(f"[{ts_text}] " if ts_text else "") + content,
+                    timestamp=None,
+                    fields={
+                        "content": content,
+                        "ts": ts_text,
+                        "itemType": _cell(row, index, "itemType"),
+                        "ai": _custom_dimensions(_cell(row, index, "customDimensions")),
+                    },
+                )
+            )
+    if not records:
+        raise ValueError("App Insights export contains no message-bearing rows")
+    records.sort(key=_sort_key)
+    return records
+
+
+def relabel_input(trace: Trace) -> Trace:
+    """Mark the trace as App-Insights-sourced without touching parser logic."""
+    return replace(
+        trace,
+        input=TraceInput(source=_SOURCE, adapter=_ADAPTER, adapter_version=_ADAPTER_VERSION),
+    )
+
+
+def _cell(row: Sequence[object], index: Mapping[str, int], name: str) -> object:
+    i = index.get(name)
+    if i is None or i >= len(row):
+        return None
+    return row[i]
+
+
+def _custom_dimensions(value: object) -> dict[str, object]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _normalize_timestamp(raw: str) -> str:
+    """Any ISO-8601 App Insights timestamp as UTC millisecond precision.
+
+    Handles the observed shapes plus defensive ones: ``Z`` suffix, ISO offsets
+    (``+09:00`` — converted to the true UTC instant, never dropped), and
+    100-nanosecond ticks (truncated to microseconds, then milliseconds).
+    Stdlib-only so Python 3.10's stricter ``fromisoformat`` is respected: the
+    ``Z`` suffix is stripped before parsing and UTC is re-applied explicitly.
+    """
+    text = raw.strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1]
+    if "." in text:
+        head, rest = text.split(".", 1)
+        digits: list[str] = []
+        i = 0
+        while i < len(rest) and rest[i].isdigit():
+            digits.append(rest[i])
+            i += 1
+        text = head + "." + ("".join(digits) + "000000")[:6] + rest[i:]
+    try:
+        moment = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"App Insights row has an unparseable timestamp: {raw!r}") from exc
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    else:
+        moment = moment.astimezone(timezone.utc)
+    return moment.strftime("%Y-%m-%dT%H:%M:%S.") + f"{moment.microsecond // 1000:03d}Z"
+
+
+def _sort_key(record: LogRecord) -> tuple[int, str]:
+    ts = record.fields.get("ts")
+    return (0, ts) if isinstance(ts, str) and ts else (1, "")

--- a/src/funcviz/cli.py
+++ b/src/funcviz/cli.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TextIO
 from urllib.request import pathname2url
 
+from funcviz.appinsights import records_from_query_result, relabel_input
 from funcviz.models import LogRecord
 from funcviz.parser import from_log_text, mask_records, parse_trace
 from funcviz.source import enrich_trace_from_source
@@ -57,6 +58,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-mask",
         action="store_true",
         help="Do not redact secrets; emit raw log text verbatim (masking is on by default).",
+    )
+    parse_cmd.add_argument(
+        "--from-appinsights",
+        action="store_true",
+        help="Treat INPUT as an 'az monitor app-insights query' JSON export, not a raw log.",
     )
     parse_cmd.set_defaults(handler=cmd_parse)
 
@@ -137,7 +143,13 @@ def main(
 def cmd_parse(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: Opener) -> int:
     text = _read_text_arg(args.input, stdin)
     trace_id = args.trace_id or _default_trace_id(args.input, text)
-    trace = parse_trace(_records(text, no_mask=args.no_mask), trace_id=trace_id)
+    if args.from_appinsights:
+        records = records_from_query_result(_read_json_export(text, args.input))
+        if not args.no_mask:
+            records = mask_records(records)
+        trace = relabel_input(parse_trace(records, trace_id=trace_id))
+    else:
+        trace = parse_trace(_records(text, no_mask=args.no_mask), trace_id=trace_id)
     if args.source:
         trace = enrich_trace_from_source(
             trace,
@@ -227,6 +239,16 @@ def _read_json_file(path_arg: str) -> object:
             return json.load(handle)
         except json.JSONDecodeError as exc:
             raise ValueError(f"{path_arg}: not valid JSON ({exc})") from exc
+
+
+def _read_json_export(text: str, input_arg: str) -> dict[str, object]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{input_arg}: not valid JSON ({exc})") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{input_arg}: expected an App Insights query-result object")
+    return data
 
 
 def _default_trace_id(input_arg: str, text: str) -> str:

--- a/tests/test_appinsights.py
+++ b/tests/test_appinsights.py
@@ -1,0 +1,186 @@
+"""App Insights query-result adapter tests (issue #67, PRD §5.1, FR-2).
+
+Fixtures mirror the shape ``az monitor app-insights query ... -o json``
+returns (``tables/columns/rows``) and the row content the discovery in issue
+#66 observed live: host Executing/Executed bookends in ``message``, ISO
+timestamps with 100-ns ticks, structured ``customDimensions``, and NO raw
+python-worker lines (App Insights never ingests them).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from funcviz import cli
+from funcviz.appinsights import records_from_query_result
+from funcviz.parser import mask_records, parse_trace
+
+ROOT = Path(__file__).resolve().parent.parent
+SUCCESS_LOG = ROOT / "samples" / "success.log"
+INVOCATION = "6a8f3658-2b31-4554-aa86-1ee32a9e679b"
+
+
+def _host_rows():
+    """Executing/Executed bookends from the real success sample, AI-shaped."""
+    rows = []
+    for line in SUCCESS_LOG.read_text().splitlines():
+        if "Executing 'Functions.hello'" in line or "Executed 'Functions.hello'" in line:
+            ts = line.split("]")[0].lstrip("[")
+            rows.append(
+                [
+                    ts,
+                    "trace",
+                    line.split("] ", 1)[1],
+                    "funcviz-ai",
+                    json.dumps({"InvocationId": INVOCATION, "ProcessId": "44"}),
+                ]
+            )
+    assert len(rows) == 2
+    return rows
+
+
+def _export(rows, *, tick_noise=True):
+    if tick_noise and rows and "." in str(rows[0][0]):
+        rows = [list(r) for r in rows]
+        rows[0][0] = str(rows[0][0])[:-1] + "6689Z"  # 100-ns ticks variant
+    return {
+        "tables": [
+            {
+                "name": "PrimaryResult",
+                "columns": [
+                    {"name": "timestamp", "type": "datetime"},
+                    {"name": "itemType", "type": "string"},
+                    {"name": "message", "type": "string"},
+                    {"name": "name", "type": "string"},
+                    {"name": "customDimensions", "type": "object"},
+                ],
+                "rows": rows,
+            }
+        ]
+    }
+
+
+def _trace_dict(export):
+    records = mask_records(records_from_query_result(export))
+    trace = parse_trace(records, trace_id="ai-001")
+    from funcviz.appinsights import relabel_input
+
+    return relabel_input(trace).to_dict()
+
+
+def test_adapter_reuses_parser_body_for_host_bookends():
+    trace = _trace_dict(_export(_host_rows()))
+    names = [e["event"] for e in trace["events"]]
+    assert names == ["InvocationStarted", "InvocationCompleted"]
+    assert trace["outcome"] == "success"
+    assert trace["input"]["source"] == "app-insights-query"
+    assert trace["input"]["adapter"] == "AppInsightsQueryAdapter"
+    assert "incomplete" not in trace.get("metadata", {})
+
+
+def test_missing_worker_lines_report_honestly_as_unknown():
+    trace = _trace_dict(_export(_host_rows()))
+    lanes = trace["lanes"]
+    assert lanes["host"]["status"] == "reached"
+    assert lanes["python-worker"]["status"] == "unknown"
+    assert lanes["client"]["status"] == "not-reached"
+
+
+def test_timestamp_tick_normalization_and_defensive_sort():
+    rows = list(reversed(_host_rows()))  # export order scrambled
+    records = records_from_query_result(_export(rows))
+    assert records[0].fields["ts"].endswith("Z")
+    assert len(records[0].fields["ts"].split(".")[1][:-1]) == 3
+    assert records[0].fields["ts"] < records[1].fields["ts"]
+    assert records[0].fields["content"].startswith("Executing")
+
+
+def test_multi_invocation_export_is_rejected_by_contract_guard():
+    other = [r[:] for r in _host_rows()]
+    for row in other:
+        row[2] = row[2].replace(INVOCATION, "7b1e4769-3c42-5b55-cc97-2ff43b0f780c")
+        row[4] = row[4].replace(INVOCATION, "7b1e4769-3c42-5b55-cc97-2ff43b0f780c")
+    try:
+        _trace_dict(_export(_host_rows() + other))
+    except ValueError as exc:
+        assert "2 invocations" in str(exc)
+    else:
+        raise AssertionError("multi-invocation export must be rejected (#85)")
+
+
+def test_messageless_rows_dropped_and_empty_export_errors():
+    export = _export([["2026-09-05T00:45:15.000Z", "request", None, "prod", "{}"]])
+    try:
+        records_from_query_result(export)
+    except ValueError as exc:
+        assert "no message-bearing rows" in str(exc)
+    else:
+        raise AssertionError("message-less export must error, not yield a blank trace")
+
+
+def test_cli_from_appinsights_flag_end_to_end(tmp_path, capsys):
+    export = tmp_path / "prod.json"
+    export.write_text(json.dumps(_export(_host_rows())))
+    out = tmp_path / "trace.json"
+    code = cli.main(
+        ["parse", str(export), "--from-appinsights", "-o", str(out)],
+        stdin=__import__("io").StringIO(""),
+        stdout=__import__("io").StringIO(),
+        stderr=__import__("io").StringIO(),
+        opener=lambda url: None,
+    )
+    assert code == 0
+    trace = json.loads(out.read_text())
+    assert trace["input"]["source"] == "app-insights-query"
+    assert [e["event"] for e in trace["events"]] == [
+        "InvocationStarted",
+        "InvocationCompleted",
+    ]
+
+
+def test_cli_rejects_non_json_as_appinsights_input(tmp_path):
+    bad = tmp_path / "prod.log"
+    bad.write_text("not json at all")
+    code, _, stderr = _run_cli(["parse", str(bad), "--from-appinsights"])
+    assert code == 1
+    assert "not valid JSON" in stderr
+
+
+def _run_cli(argv):
+    import io
+
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = cli.main(
+        argv, stdin=io.StringIO(""), stdout=stdout, stderr=stderr, opener=lambda url: None
+    )
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_offset_timestamp_converts_to_true_utc_instant():
+    from funcviz.appinsights import _normalize_timestamp
+
+    assert _normalize_timestamp("2026-09-05T09:45:15.123+09:00") == "2026-09-05T00:45:15.123Z"
+    assert _normalize_timestamp("2026-09-05T00:45:15-03:30") == "2026-09-05T04:15:15.000Z"
+    assert _normalize_timestamp("2026-09-05T00:45:15.1234567Z") == "2026-09-05T00:45:15.123Z"
+    assert _normalize_timestamp("2026-09-05T00:45:15Z") == "2026-09-05T00:45:15.000Z"
+    # regression shape: 100-ns ticks combined with an ISO offset
+    assert _normalize_timestamp("2026-09-05T09:45:15.1234567+09:00") == "2026-09-05T00:45:15.123Z"
+
+
+def test_unparseable_timestamp_is_a_clear_adapter_error():
+    import pytest
+
+    from funcviz.appinsights import _normalize_timestamp
+
+    with pytest.raises(ValueError, match="unparseable timestamp"):
+        _normalize_timestamp("not-a-timestamp")
+
+
+def test_message_row_without_timestamp_errors_at_adapter():
+    rows = _host_rows()
+    rows[0][0] = None
+    import pytest
+
+    with pytest.raises(ValueError, match="without a timestamp"):
+        records_from_query_result(_export(rows, tick_noise=False))


### PR DESCRIPTION
## Summary
- new appinsights.py adapter: az CLI `tables/columns/rows` exports flatten into the exact `from_log_text` LogRecord shape, so the pure parser runs with zero edits (FR-2 validated)
- timestamps normalize any ISO form to true UTC milliseconds — Z suffix, ISO offsets converted via astimezone (never dropped), 100-ns ticks truncated; message-less rows drop, timestamp-less message rows and unparseable stamps fail at the adapter with clear errors
- masking stays on by default; `#85` single-invocation and `#84` incomplete guards compose automatically; input relabeled app-insights-query via the source.py replace pattern
- honest lossiness per discovery #66: worker lane `unknown`, client lane `not-reached` in export-built traces; README gains a production-logs subsection tied to the §3.1 guardrail

## Verification
- 158 tests passed (10 new); Ruff and LSP clean; goldens byte-identical
- end-to-end: real-shaped export → CLI → trace (correct source/adapter, bookends parsed, honest lanes) → viewer renders, 0 console errors
- multi-invocation export rejected by the contract guard; offset/tick timestamp matrix asserted including the ticks+offset regression shape
- Oracle 96/100 (offset blocker found at 88, fixed and re-verified)

Closes #67