### PR TITLE
feat: App Insights ordering strategy + host-instance annotation (#68)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -197,6 +197,16 @@ local captures — how far the run got, which component owned each step, what is
 inferred. Latency aggregation, dependency analytics, and performance baselines stay in App
 Insights; a funcviz trace never becomes a dashboard.
 
+**Ordering strategy (#68):** local single-stdout order does not exist in App Insights, so
+sequence assignment for adapter input is timestamp-primary — rows sort by ``timestamp``
+ascending before parsing, with the export's row order as the deterministic tie-break when
+timestamps collide at the adapter's millisecond normalization (sub-ms tick detail is
+intentionally truncated before parsing). Two fences keep that honest at scale: the single-invocation contract rejects
+exports whose messages span more than one invocation id (#85), and an export whose rows carry
+more than one distinct ``HostInstanceId`` is annotated ``metadata.hostInstances`` rather than
+silently implying one instance — a single invocation lives on one host instance, so a span
+means the query reached beyond one invocation's story.
+
 **This is not built in v0.1.** The only v0.1 obligation is FR-2's record shape, so that adding the
 adapter later is an addition rather than a rewrite. Nothing else in this document changes for it.
 

--- a/src/funcviz/appinsights.py
+++ b/src/funcviz/appinsights.py
@@ -96,6 +96,31 @@ def relabel_input(trace: Trace) -> Trace:
     )
 
 
+def with_host_instances(trace: Trace, records: Sequence[LogRecord]) -> Trace:
+    """Annotate the trace when an export spans multiple host instances (#68).
+
+    A single invocation lives on one host instance, so distinct
+    ``HostInstanceId`` values among an export's rows mean the query reached
+    beyond one invocation's story (or caught special-controller noise). The
+    trace is still built — ordering is timestamp-primary — but the span is
+    recorded in ``metadata.hostInstances`` instead of silently implying one
+    instance. Existing metadata (e.g. the #84 incomplete marker) is preserved.
+    """
+    ids: list[str] = []
+    for record in records:
+        ai = record.fields.get("ai")
+        if not isinstance(ai, Mapping):
+            continue
+        value = ai.get("HostInstanceId")
+        if isinstance(value, str) and value and value not in ids:
+            ids.append(value)
+    if len(ids) < 2:
+        return trace
+    metadata = dict(trace.metadata)
+    metadata["hostInstances"] = ids
+    return replace(trace, metadata=metadata)
+
+
 def _cell(row: Sequence[object], index: Mapping[str, int], name: str) -> object:
     i = index.get(name)
     if i is None or i >= len(row):

--- a/src/funcviz/cli.py
+++ b/src/funcviz/cli.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import TextIO
 from urllib.request import pathname2url
 
-from funcviz.appinsights import records_from_query_result, relabel_input
+from funcviz.appinsights import records_from_query_result, relabel_input, with_host_instances
 from funcviz.models import LogRecord
 from funcviz.parser import from_log_text, mask_records, parse_trace
 from funcviz.source import enrich_trace_from_source
@@ -147,7 +147,7 @@ def cmd_parse(args, *, stdin: TextIO, stdout: TextIO, stderr: TextIO, opener: Op
         records = records_from_query_result(_read_json_export(text, args.input))
         if not args.no_mask:
             records = mask_records(records)
-        trace = relabel_input(parse_trace(records, trace_id=trace_id))
+        trace = with_host_instances(relabel_input(parse_trace(records, trace_id=trace_id)), records)
     else:
         trace = parse_trace(_records(text, no_mask=args.no_mask), trace_id=trace_id)
     if args.source:

--- a/tests/test_appinsights.py
+++ b/tests/test_appinsights.py
@@ -184,3 +184,73 @@ def test_message_row_without_timestamp_errors_at_adapter():
 
     with pytest.raises(ValueError, match="without a timestamp"):
         records_from_query_result(_export(rows, tick_noise=False))
+
+
+def test_equal_ms_timestamps_fall_back_to_export_order():
+    """#68 — ms-precision ties keep the export's row order (stable sort)."""
+    rows = _host_rows()
+    same = "2026-09-05T00:45:15.400Z"
+    rows[0][0] = same
+    rows[1][0] = same
+    records = records_from_query_result(_export(rows, tick_noise=False))
+    assert [r.fields["content"][:9] for r in records] == ["Executing", "Executed "]
+
+
+def test_multi_host_instance_export_is_annotated_not_silent():
+    """#68 — spanning host instances lands in metadata.hostInstances."""
+    from funcviz.appinsights import relabel_input, with_host_instances
+    from funcviz.parser import parse_trace
+
+    rows = _host_rows()
+    rows[0][4] = rows[0][4].replace("ProcessId", "HostInstanceId\":\"h-1\",\"ProcessId")
+    rows[1][4] = rows[1][4].replace("ProcessId", "HostInstanceId\":\"h-2\",\"ProcessId")
+    records = mask_records(records_from_query_result(_export(rows, tick_noise=False)))
+    trace = with_host_instances(relabel_input(parse_trace(records, trace_id="ai-2")), records)
+    assert trace.metadata.get("hostInstances") == ["h-1", "h-2"]
+    # single distinct id -> no annotation
+    rows2 = _host_rows()
+    for r in rows2:
+        r[4] = r[4].replace("ProcessId", "HostInstanceId\":\"h-1\",\"ProcessId")
+    records2 = mask_records(records_from_query_result(_export(rows2, tick_noise=False)))
+    trace2 = with_host_instances(relabel_input(parse_trace(records2, trace_id="ai-3")), records2)
+    assert "hostInstances" not in trace2.metadata
+
+
+def test_host_instances_annotation_preserves_existing_metadata():
+    """#68 — adding hostInstances must not clobber the #84 incomplete marker."""
+    from funcviz.appinsights import records_from_query_result, with_host_instances
+    from funcviz.parser import parse_trace
+
+    rows = _host_rows()
+    rows[0][4] = rows[0][4].replace("ProcessId", "HostInstanceId\":\"h-1\",\"ProcessId")
+    rows[1][4] = rows[1][4].replace("ProcessId", "HostInstanceId\":\"h-2\",\"ProcessId")
+    records = records_from_query_result(_export(rows, tick_noise=False))
+    from dataclasses import replace as _replace
+
+    trace = _replace(parse_trace(records, trace_id="t"), metadata={"incomplete": True})
+    merged = with_host_instances(trace, records).to_dict()
+    assert merged["metadata"]["incomplete"] is True
+    assert merged["metadata"]["hostInstances"] == ["h-1", "h-2"]
+
+
+def test_cli_wires_host_instances_annotation(tmp_path):
+    """#68 — the CLI path emits metadata.hostInstances for a multi-host export."""
+    import io
+    import json as jsonlib
+
+    rows = _host_rows()
+    rows[0][4] = rows[0][4].replace("ProcessId", "HostInstanceId\":\"h-1\",\"ProcessId")
+    rows[1][4] = rows[1][4].replace("ProcessId", "HostInstanceId\":\"h-2\",\"ProcessId")
+    export = tmp_path / "multi-host.json"
+    export.write_text(jsonlib.dumps(_export(rows, tick_noise=False)))
+    out = tmp_path / "trace.json"
+    code = cli.main(
+        ["parse", str(export), "--from-appinsights", "-o", str(out)],
+        stdin=io.StringIO(""),
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        opener=lambda url: None,
+    )
+    assert code == 0
+    trace = jsonlib.loads(out.read_text())
+    assert trace["metadata"]["hostInstances"] == ["h-1", "h-2"]


### PR DESCRIPTION
## Summary
- sequence assignment for adapter input is timestamp-primary with the export's row order as the deterministic equal-ms tie-break (stable sort, tested)
- exports spanning multiple distinct HostInstanceId values are annotated metadata.hostInstances (merge-preserving, keeps the #84 incomplete marker) rather than rejected — a single invocation lives on one host instance, so a span is provenance, not contract breach
- PRD §5.1 documents the full strategy: ordering, tie-break, tick truncation, and the two fences (#85 rejection, hostInstances annotation)

## Verification
- 162 tests passed (4 new: equal-ms tie order, multi-host annotation, single-host non-annotation, metadata preservation + CLI wiring); Ruff and LSP clean; goldens byte-identical
- Oracle 94/100, no blockers (all three nits applied)

Closes #68