### PR TITLE
docs: publish interactive viewer demo on GitHub Pages (#100)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,49 @@
+name: pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e ".[dev]"
+      - run: make pages-check
+      - run: python -m playwright install --with-deps chromium
+      - run: FUNCVIZ_E2E=1 FUNCVIZ_PAGES_HTML=site/index.html pytest -q tests/test_pages_e2e.py
+      - uses: actions/configure-pages@v6
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+      - uses: actions/upload-pages-artifact@v5
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        with:
+          path: site
+          include-hidden-files: true
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build-and-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .eggs/
 build/
 dist/
+site/
 .venv/
 .venv-dev/
 venv/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 PYTHON ?= python3
 
-.PHONY: traces traces-check
+.PHONY: traces traces-check pages pages-check
 
 traces:
 	$(PYTHON) scripts/regen_traces.py
 
 traces-check:
 	$(PYTHON) scripts/regen_traces.py --check
+
+pages:
+	rm -rf site
+	mkdir -p site
+	PYTHONPATH=src $(PYTHON) -m funcviz.cli view traces/invocation-fail.json --html-out site/index.html
+	touch site/.nojekyll
+
+pages-check: pages
+	test -s site/index.html
+	test "$$(grep -c 'id="funcviz-default-trace"' site/index.html)" -eq 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Azure Functions Runtime Visualizer (`funcviz`)
 
+[**Try the interactive demo on GitHub Pages →**](https://yeongseon.dev/azure-functions-runtime-visualizer/)
+
 Turn Azure Functions verbose runtime logs into an interactive, replayable execution timeline that
 separates **Client**, **Functions Host**, and **Python Worker** activity — alongside the
 application source file that was executed.
@@ -12,6 +14,10 @@ stopped at the real failure boundary of +285 ms](docs/hero.png)
 `funcviz` **reads logs**. It does not launch, wrap, or manage the Functions host. You run your
 Function App with verbose logging, save the output, and `funcviz` turns it into a trace you can
 step through and inspect line-by-line against the original log text.
+
+The hosted demo uses an embedded sample trace. Files and pasted traces are processed only in your
+browser and are not uploaded, but traces can contain raw log lines or embedded source code — review
+them before sharing.
 
 > **Status:** early development (v0.1 in progress). Local Azure Functions + Python + HTTP trigger,
 > log-file input, replay-only. See [`PRD.md`](PRD.md) for the full scope and decision log.

--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'">
 <meta name="description" content="funcviz static viewer — renders an Azure Functions runtime trace two ways: a Presentation execution-flow storyboard (client / functions host / python worker / application) and an Inspect four-swimlane timeline over one shared elapsed-time axis, both beside the application source panel.">
 <title>funcviz — trace viewer</title>
 <style>
@@ -176,6 +177,9 @@
   }
   #tracePaste::placeholder { color: var(--text-faint); }
   .load-status { margin: 0 0 0 auto; font-size: 12px; color: var(--text-faint); font-family: var(--mono); }
+  .local-only-note {
+    flex: 1 1 100%; margin: 0; font-size: 11px; color: var(--text-faint);
+  }
   .load-status--ok { color: var(--ok-strong); }
   .load-status--error { color: var(--fail-strong); }
   .btn:disabled { opacity: .45; cursor: not-allowed; }
@@ -1577,6 +1581,7 @@
   <textarea id="tracePaste" rows="1" placeholder="…or paste trace JSON here" aria-label="Paste trace JSON" spellcheck="false"></textarea>
   <button type="button" class="btn btn--primary" id="loadPasteBtn">Load pasted trace</button>
   <p class="load-status" id="loadStatus" role="status" aria-live="polite"></p>
+  <p class="local-only-note">Files and pasted traces stay in this browser. funcviz makes no network requests. Sample traces may include raw log lines and embedded source; review them before sharing.</p>
 </section>
 
 <!-- issue #10 — persistent honesty banner; body populated by
@@ -3071,8 +3076,8 @@
   }
 
   function buildConnectorLine(fromEv, toEv, mainRect, forensic) {
-    var fromNode = document.querySelector('.event[data-event-id="' + fromEv.id + '"]');
-    var toNode = document.querySelector('.event[data-event-id="' + toEv.id + '"]');
+    var fromNode = eventNodeById(fromEv.id);
+    var toNode = eventNodeById(toEv.id);
     var kind = null;
     var a = null;
     var b = null;
@@ -3096,6 +3101,15 @@
         (kind === "observed" ? "Observed" : "Inferred") + ")");
     }
     return line;
+  }
+
+  function eventNodeById(id) {
+    var nodes = document.querySelectorAll(".event[data-event-id]");
+    var i = 0;
+    for (i = 0; i < nodes.length; i++) {
+      if (nodes[i].getAttribute("data-event-id") === String(id)) return nodes[i];
+    }
+    return null;
   }
 
   function renderConnectors() {
@@ -4532,7 +4546,7 @@
     updateStackPanel();
     updatePresentationView(); /* #97 — story/actors/handoffs follow the selection */
     if (opts && opts.focus) {
-      node = document.querySelector('.event[data-event-id="' + id + '"]');
+      node = eventNodeById(id);
       if (node) node.focus();
     }
     return true;

--- a/tests/test_pages_e2e.py
+++ b/tests/test_pages_e2e.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("FUNCVIZ_E2E") != "1" or not os.environ.get("FUNCVIZ_PAGES_HTML"),
+    reason="set FUNCVIZ_E2E=1 and FUNCVIZ_PAGES_HTML to run Pages smoke tests",
+)
+
+
+def test_pages_artifact_is_interactive_and_local_only():
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = Path(os.environ["FUNCVIZ_PAGES_HTML"]).resolve()
+    assert html.is_file()
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        requests: list[str] = []
+        page.on("request", lambda request: requests.append(request.url))
+        page.goto(html.as_uri())
+        assert page.locator("body").get_attribute("data-view-mode") == "presentation"
+        assert page.locator("#presentationEvent").text_content() == "Ready to replay"
+        page.locator("#presentationNextBtn").click()
+        assert page.locator("#presentationEvent").text_content() != "Ready to replay"
+        page.locator("#inspectTab").click()
+        assert page.locator("#lanes .lane").count() == 4
+        page.locator("#presentationTab").click()
+        note = page.locator(".local-only-note").text_content()
+        assert "stay in this browser" in note
+        assert all(url.startswith("file:") for url in requests)
+        browser.close()


### PR DESCRIPTION
## Summary
- build the exact CLI-rendered invocation-fail viewer as `site/index.html` (`make pages`), never a handwritten demo copy
- PR/main artifact smoke test in Chromium; main-only deployment via official configure-pages/upload-pages-artifact/deploy-pages actions with least job permissions
- add strict no-network CSP, browser-local privacy notice, and trace-controlled event-ID selector hardening
- link the real custom-domain Pages URL from README and document raw-log/source sensitivity

## Verification
- `make pages-check` → artifact + one embedded trace island
- Pages artifact Chromium smoke: 1 passed (Presentation default/replay, Inspect switch, local-only copy, no network request)
- standard: 162 passed / 8 browser tests skipped; Ruff, LSP, traces-check, YAML validation
- Pages pre-enabled with `build_type=workflow`, HTTPS enforced; live target: https://yeongseon.dev/azure-functions-runtime-visualizer/
- Oracle 91/100, all workflow nits applied (hidden .nojekyll, main-only dispatch/deploy, activation race removed)

Closes #100