### PR TITLE
feat(viewer): collapse trace loading behind Open trace (#105)

### DIFF
--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -155,13 +155,51 @@
   }
 
   /* ============================================================
-     toolbar — trace loading (file / paste / default)
+     trace loader — #105 disclosure. The always-open toolbar chrome
+     collapses behind a native details row: CLOSED at rest (one compact
+     summary line recovers the vertical space before the schematic),
+     OPEN reveals the unchanged toolbar (same ids/actions/note).
+     Native details = free mouse/keyboard toggling, focus and AT
+     semantics; descendants leave the focus order while closed.
      ============================================================ */
-  .toolbar {
-    display: flex; flex-wrap: wrap; align-items: center; gap: var(--sp-2);
-    padding: var(--sp-3) var(--sp-5);
+  .trace-loader {
     border-bottom: 1px solid var(--border);
     background: var(--bg-raised);
+  }
+  .trace-loader summary {
+    display: flex; align-items: center; gap: var(--sp-3);
+    padding: var(--sp-2) var(--sp-5);
+    cursor: pointer;
+    list-style: none;
+    font-family: var(--mono); font-size: 12px; font-weight: 700;
+    letter-spacing: .8px; text-transform: uppercase;
+    color: var(--text-dim);
+    border-radius: 0; /* flat band, never a pill */
+  }
+  .trace-loader summary::-webkit-details-marker { display: none; }
+  .trace-loader summary:hover { color: var(--text); background: rgba(0, 0, 0, .03); }
+  .trace-loader summary:focus-visible { outline: 2px solid var(--text); outline-offset: -2px; }
+  .trace-loader-meta {
+    min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-weight: 400; letter-spacing: 0; text-transform: none; font-size: 11px;
+    color: var(--text-faint);
+  }
+  .trace-loader summary::after { /* chevron drawn from borders — survives forced colors */
+    content: ""; flex: none; margin-left: auto;
+    width: 7px; height: 7px;
+    border-right: 2px solid currentColor; border-bottom: 2px solid currentColor;
+    transform: rotate(45deg); /* ▾ closed */
+  }
+  .trace-loader[open] summary::after { transform: rotate(225deg); } /* ▴ open */
+  .trace-loader[open] summary { border-bottom: 0; }
+  /* the toolbar itself is unchanged chrome, restyled only inside the panel:
+     flat, compact, separated from the summary by a hairline */
+  .trace-loader .toolbar {
+    display: flex; flex-wrap: wrap; align-items: center; gap: var(--sp-2);
+    padding: var(--sp-2) var(--sp-5) var(--sp-3);
+    border-bottom: none;
+    border-top: 1px solid var(--border);
+    background: transparent;
   }
   .btn {
     display: inline-flex; align-items: center; gap: var(--sp-1);
@@ -1509,6 +1547,9 @@
     .pres-handoff[data-active="true"] .ph-pulse { background: Highlight; }
     .playhead { background: Highlight; }
     .pres-scrubber-fill { background: Highlight; }
+    /* #105 — disclosure chevron + focus stay visible with system colors */
+    .trace-loader summary::after { border-color: CanvasText; }
+    .trace-loader summary:focus-visible { outline: 2px solid Highlight; outline-offset: -2px; }
   }
 
   @media (max-width: 1080px) {
@@ -1543,6 +1584,10 @@
     .lane-reason { font-size: 10px; }
     .runtime-meta { margin-left: 0; flex-basis: 100%; text-align: left; }
     .load-status { margin-left: 0; flex-basis: 100%; }
+    /* #105 — disclosure row fits 360px: tighter padding; the meta label
+       already ellipsizes (min-width 0) and the caret is pinned right */
+    .trace-loader summary { padding: var(--sp-2) var(--sp-4); }
+    .trace-loader .toolbar { padding: var(--sp-2) var(--sp-4) var(--sp-3); }
     .view-switch { padding: 0 var(--sp-4); }
     .view-switch-note { flex-basis: 100%; }
     /* #97 — the shared banner must fit the mobile Presentation viewport:
@@ -1582,6 +1627,8 @@
   <p class="runtime-meta" id="runtimeMeta"></p>
 </header>
 
+<details id="traceLoader" class="trace-loader">
+<summary id="traceLoaderSummary"><span class="trace-loader-title">Open trace</span><span class="trace-loader-meta" id="traceLoaderMeta" aria-hidden="true">loaded locally</span></summary>
 <section class="toolbar" aria-label="Trace loading">
   <label class="btn" for="traceFile">Open trace file…</label>
   <input type="file" id="traceFile" accept="application/json,.json" class="vh">
@@ -1591,6 +1638,7 @@
   <p class="load-status" id="loadStatus" role="status" aria-live="polite"></p>
   <p class="local-only-note">Files and pasted traces stay in this browser. funcviz makes no network requests. Sample traces may include raw log lines and embedded source; review them before sharing.</p>
 </section>
+</details>
 
 <!-- issue #10 — persistent honesty banner; body populated by
      renderConfidenceBanner() from lanes[*].status/confidence only.
@@ -4791,6 +4839,7 @@
   /* ---------------- public renderer API ---------------------------------- */
   function renderTrace(trace) {
     currentTrace = trace;
+    updateTraceLoaderMeta(trace); /* #105 — summary secondary label: traceId / loaded locally */
     clearPlaybackTimer(); /* never a dangling timer across loads (#7) */
     playbackState = "idle";
     orderedEvents = (trace && trace.events
@@ -4842,6 +4891,24 @@
     setStatus("Viewer cleared. Load a trace to render.", "");
   }
 
+  /* ---------------- #105 — trace loader disclosure ---------------------- */
+  /* Native details state helper: success closes (chrome out of the way),
+     failures open (error + controls stay visible/focusable). The quiet boot
+     load never touches it — the disclosure starts closed and stays closed. */
+  function setTraceLoaderOpen(open, returnFocus) {
+    var details = document.getElementById("traceLoader");
+    var summary = document.getElementById("traceLoaderSummary");
+    if (details) details.open = !!open;
+    if (!open && returnFocus && summary) summary.focus();
+  }
+
+  function updateTraceLoaderMeta(trace) {
+    var meta = document.getElementById("traceLoaderMeta");
+    if (meta) {
+      meta.textContent = trace ? (trace.traceId || "loaded locally") : "no trace loaded";
+    }
+  }
+
   function setStatus(msg, kind) {
     var node = document.getElementById("loadStatus");
     node.textContent = msg || "";
@@ -4854,11 +4921,13 @@
     var res = parseTraceJson(text);
     if (!res.ok) {
       setStatus(label + ": " + res.error, "error");
+      setTraceLoaderOpen(true); /* #105 — error must stay visible */
       return false;
     }
     renderTrace(res.trace);
     setStatus("Loaded " + label + " — " + res.trace.events.length + " events, outcome: " +
       _outcomeLabel(res.trace) + ".", "ok");
+    setTraceLoaderOpen(false, true); /* #105 — close and return keyboard focus */
     return true;
   }
 
@@ -4867,12 +4936,15 @@
     var res = parseTraceJson(node.textContent);
     if (!res.ok) {
       setStatus("Built-in default trace failed to parse: " + res.error, "error");
-      return;
+      if (!quiet) setTraceLoaderOpen(true); /* #105 — explicit restore: surface the error */
+      return false;
     }
     renderTrace(res.trace);
     var summary = "Showing embedded trace (" + (res.trace.traceId || "unknown") + ") — " +
       res.trace.events.length + " events, outcome: " + _outcomeLabel(res.trace) + ".";
     setStatus(quiet ? summary : "Restored default trace — " + summary, "ok");
+    if (!quiet) setTraceLoaderOpen(false, true); /* explicit restore returns focus */
+    return true;
   }
 
   /* #84 — status lines must not report a fallback outcome as observed fact */
@@ -4888,11 +4960,14 @@
     if (!file) return;
     var reader = new FileReader();
     reader.onload = function () {
+      /* loadTraceText owns the #105 disclosure state: closes on success,
+         re-opens on parse failure — file selection alone never closes */
       loadTraceText(String(reader.result), file.name);
       input.value = "";
     };
     reader.onerror = function () {
       setStatus("Could not read " + file.name + ".", "error");
+      setTraceLoaderOpen(true); /* #105 — read error keeps controls visible */
       input.value = "";
     };
     reader.readAsText(file);
@@ -4902,6 +4977,7 @@
     var ta = document.getElementById("tracePaste");
     if (!ta.value.trim()) {
       setStatus("Paste trace JSON into the box first.", "error");
+      setTraceLoaderOpen(true); /* #105 — empty paste: keep the box in view */
       return;
     }
     loadTraceText(ta.value, "pasted JSON");
@@ -4998,6 +5074,11 @@
     renderTrace: renderTrace,
     parseTraceJson: parseTraceJson,
     clear: clear,
+    /* #105 — trace loader disclosure state (headless assertion hook) */
+    traceLoaderOpen: function () {
+      var details = document.getElementById("traceLoader");
+      return !!(details && details.open);
+    },
     selectEvent: selectEvent,
     getSelectedEventId: getSelectedEventId,
     getOrderedEventIds: getOrderedEventIds,

--- a/tests/test_pages_e2e.py
+++ b/tests/test_pages_e2e.py
@@ -28,6 +28,8 @@ def test_pages_artifact_is_interactive_and_local_only():
         page.locator("#inspectTab").click()
         assert page.locator("#lanes .lane").count() == 4
         page.locator("#presentationTab").click()
+        # #105 — the local-only privacy note lives inside the loader disclosure
+        page.locator("#traceLoaderSummary").click()
         note = page.locator(".local-only-note").text_content()
         assert "stay in this browser" in note
         assert all(url.startswith("file:") for url in requests)

--- a/tests/test_viewer_e2e.py
+++ b/tests/test_viewer_e2e.py
@@ -153,6 +153,8 @@ def test_repeated_handoff_uses_latest_crossing_confidence(tmp_path):
         browser = pw.chromium.launch()
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         page.goto(html.as_uri())
+        # #105 — the loader toolbar lives behind the disclosure at rest
+        page.locator("#traceLoaderSummary").click()
         page.locator("#tracePaste").fill(json.dumps(trace))
         page.locator("#loadPasteBtn").click()
         page.locator("#presentationNextBtn").click()
@@ -389,4 +391,162 @@ def test_visual_light_semantic_text_is_accessibly_dark(tmp_path):
             ["color"],
         )
         assert idle_text["color"] == "rgb(96, 94, 92)"
+        browser.close()
+
+
+# --------------------------------------------------------------------------
+# #105 — trace loader disclosure contracts. Native details: closed at rest
+# (toolbar chrome leaves the layout AND the focus order), opens on toggle,
+# closes on successful loads, stays open on failures.
+# --------------------------------------------------------------------------
+
+
+def _wait_loader_closed(page, timeout=3.0):
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if page.evaluate("window.Funcviz.traceLoaderOpen()") is False:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def test_trace_loader_starts_closed_hiding_toolbar(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        assert page.evaluate("window.Funcviz.traceLoaderOpen()") is False  # closed at rest
+        assert page.locator("#traceLoaderSummary").is_visible()
+        assert not page.locator("#tracePaste").is_visible()  # controls not rendered
+        assert not page.locator("#loadStatus").is_visible()  # status hidden with panel
+        closed_h = page.evaluate(
+            "() => document.querySelector('#traceLoader').getBoundingClientRect().height"
+        )
+        switch_top_closed = page.evaluate(
+            "() => document.querySelector('.view-switch').getBoundingClientRect().top"
+        )
+        page.locator("#traceLoaderSummary").click()
+        open_h = page.evaluate(
+            "() => document.querySelector('#traceLoader').getBoundingClientRect().height"
+        )
+        switch_top_open = page.evaluate(
+            "() => document.querySelector('.view-switch').getBoundingClientRect().top"
+        )
+        # space recovery: closed row is a thin strip; the view switch sits
+        # higher than the always-open toolbar baseline it replaces
+        assert closed_h < 45
+        assert open_h > closed_h + 60
+        assert switch_top_closed < switch_top_open - 60
+        browser.close()
+
+
+def test_trace_loader_opens_controls_visible_focusable(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.focus("#traceLoaderSummary")
+        page.keyboard.press("Enter")  # native keyboard toggle
+        assert page.evaluate("window.Funcviz.traceLoaderOpen()") is True
+        for selector in (
+            "#traceFile",
+            "#resetBtn",
+            "#tracePaste",
+            "#loadPasteBtn",
+            ".local-only-note",
+        ):
+            assert page.locator(selector).is_visible(), selector
+        page.locator("#loadPasteBtn").focus()
+        focused = page.evaluate("() => document.activeElement.id")
+        assert focused == "loadPasteBtn"  # controls join the focus order when open
+        browser.close()
+
+
+def test_invalid_paste_keeps_loader_open_with_error(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.locator("#traceLoaderSummary").click()
+        page.locator("#tracePaste").fill("not json")
+        page.locator("#loadPasteBtn").click()
+        assert page.evaluate("window.Funcviz.traceLoaderOpen()") is True
+        status = page.locator("#loadStatus")
+        assert "Invalid JSON" in status.text_content()
+        assert "error" in status.get_attribute("class")
+        assert status.is_visible()
+        browser.close()
+
+
+def test_valid_paste_closes_loader_and_updates_trace(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "worker-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.locator("#traceLoaderSummary").click()
+        assert page.locator("#presentationScrubberEnd").text_content() == "+2942 ms"
+        page.locator("#tracePaste").fill((ROOT / "traces" / "success.json").read_text())
+        page.locator("#loadPasteBtn").click()
+        assert _wait_loader_closed(page)
+        assert "Loaded pasted JSON" in page.locator("#loadStatus").text_content()
+        assert page.locator("#presentationScrubberEnd").text_content() == "+294 ms"
+        assert page.locator("#traceLoaderMeta").text_content() == "success-001"
+        assert page.evaluate("() => document.activeElement.id") == "traceLoaderSummary"
+        browser.close()
+
+
+def test_restore_default_closes_loader(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "worker-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.locator("#traceLoaderSummary").click()
+        page.locator("#resetBtn").click()
+        assert _wait_loader_closed(page)
+        assert "Restored default trace" in page.locator("#loadStatus").text_content()
+        assert page.evaluate("() => document.activeElement.id") == "traceLoaderSummary"
+        browser.close()
+
+
+def test_file_input_load_closes_loader(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "worker-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.locator("#traceLoaderSummary").click()
+        page.set_input_files("#traceFile", str(ROOT / "traces" / "success.json"))
+        assert _wait_loader_closed(page)  # closes only after read+parse succeed
+        assert "Loaded success.json" in page.locator("#loadStatus").text_content()
+        browser.close()
+
+
+def test_trace_loader_360_no_overflow(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 360, "height": 1600})
+        page.goto(html.as_uri())
+        assert page.evaluate("document.documentElement.scrollWidth") == 360
+        assert page.locator("#traceLoaderSummary").is_visible()
+        summary_w = page.evaluate(
+            "() => document.querySelector('#traceLoaderSummary').getBoundingClientRect().width"
+        )
+        assert summary_w <= 360
+        page.locator("#traceLoaderSummary").click()
+        assert page.evaluate("document.documentElement.scrollWidth") == 360
         browser.close()


### PR DESCRIPTION
## Summary
- wrap the existing shared file/default/paste/privacy toolbar in a native Open trace details disclosure, closed by default
- successful file/paste/default loads close the disclosure and return keyboard focus to its summary; errors keep it open and visible
- preserve all loader IDs/actions, trace/reset semantics, CSP, Presentation/Inspect state, and Pages behavior
- recover ~51px before the schematic at desktop rest state

## Verification
- standard: 162 passed / 19 browser contracts skipped; Ruff, LSP, traces, Pages artifact
- Chromium viewer E2E: 18 passed (7 new disclosure lifecycle/a11y/mobile contracts)
- Pages artifact smoke: 1 passed
- all four goldens, closed/open at 1440/360: 0 console/network errors; no overflow
- Oracle 93/100, no blockers; post-success focus nit fixed before PR

Closes #105