### PR TITLE
feat(viewer): compact Presentation confidence legend (#106)

### DIFF
--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -325,6 +325,57 @@
   .confidence-detail { margin: 0 0 var(--sp-2); font-size: 13px; line-height: 1.6; color: var(--text-dim); }
 
   /* ============================================================
+     #106 — compact Presentation confidence legend. ONE banner, two
+     projections of the same renderConfidenceBanner data: Presentation
+     shows a one-line signal-grammar strip (no title, no counts, no
+     Details toggle/body); Inspect keeps the full banner exactly as
+     before. body[data-view-mode] CSS only — display:none removes the
+     hidden projection from layout AND the a11y/focus tree; the
+     collapsed state + toggle survive every mode switch untouched.
+     Default (pre-boot, no data-view-mode) = presentation, the boot mode.
+     ============================================================ */
+  .confidence-legend {
+    display: flex; flex-wrap: wrap; align-items: center;
+    gap: var(--sp-1) var(--sp-4);
+    margin: 0; padding: 0; list-style: none;
+    font-family: var(--mono); font-size: 11px; color: var(--text-dim);
+    min-height: 22px;
+  }
+  .confidence-legend-item {
+    display: inline-flex; align-items: center; gap: 7px; white-space: nowrap;
+  }
+  /* samples mirror the schematic conductor grammar exactly — style is the
+     cue, color only confirms (never the sole signal) */
+  .confidence-legend-sample {
+    flex: none; width: 18px; height: 0;
+    border-top: 2px solid var(--schem-line);
+  }
+  .confidence-legend-sample--inferred { border-top-style: dashed; }
+  .confidence-legend-sample--not-reached { border-top-style: dotted; }
+  .confidence-legend-sample--unknown { /* hatched hollow square — unknown terminal grammar */
+    width: 10px; height: 10px;
+    border: 1px solid var(--text-dim);
+    background-image: repeating-linear-gradient(-45deg,
+      rgba(50, 49, 48, .35) 0 3px, rgba(50, 49, 48, 0) 3px 6px);
+  }
+  .confidence-legend-empty { color: var(--text-faint); }
+  /* Presentation strip: full banner chrome hidden; banner padding clamps the
+     band to the 28–34px target (5px + 22px legend + 5px + 2px borders) */
+  #confidenceBanner .confidence-head,
+  #confidenceBanner .confidence-body { display: none; }
+  #confidenceBanner { padding: 5px var(--sp-4); }
+  /* Inspect: the exact #61 banner — head row, counts, Details toggle, body */
+  body[data-view-mode="inspect"] #confidenceBanner { padding: var(--sp-2) var(--sp-4); }
+  body[data-view-mode="inspect"] #confidenceBanner .confidence-head { display: flex; }
+  body[data-view-mode="inspect"] #confidenceBanner .confidence-body { display: grid; }
+  body[data-view-mode="inspect"] #confidenceBanner .confidence-legend { display: none; }
+  @media (forced-colors: active) {
+    /* #106 — samples stay grammar-distinct with system colors */
+    #confidenceBanner .confidence-legend-sample { border-top-color: CanvasText; }
+    #confidenceBanner .confidence-legend-sample--unknown { border-color: CanvasText; }
+  }
+
+  /* ============================================================
      replay transport (#7) — sticky inside the timeline column
      ============================================================ */
   .replay-controls {
@@ -1591,8 +1642,12 @@
     .view-switch { padding: 0 var(--sp-4); }
     .view-switch-note { flex-basis: 100%; }
     /* #97 — the shared banner must fit the mobile Presentation viewport:
-       title/toggle stay together and counts get their own row. */
-    .confidence-head { display: grid; grid-template-columns: minmax(0, 1fr) auto; }
+       title/toggle stay together and counts get their own row.
+       #106 — the head only exists in Inspect now; scope the grid to it so
+       the id-scoped flex restore above cannot out-specify the mobile layout */
+    body[data-view-mode="inspect"] #confidenceBanner .confidence-head {
+      display: grid; grid-template-columns: minmax(0, 1fr) auto;
+    }
     .confidence-banner-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
     .confidence-oneline { grid-column: 1 / -1; width: 100%; }
     .pres-layout { padding: var(--sp-3) var(--sp-3) var(--sp-4); }
@@ -2191,6 +2246,7 @@
     var body;
     var inner;
     var summary;
+    var legend;
 
     for (i = 0; trace && i < CONFIDENCE_LANE_ORDER.length; i++) {
       key = CONFIDENCE_LANE_ORDER[i];
@@ -2262,6 +2318,38 @@
     inner = el("div", "confidence-body-inner");
     body.appendChild(inner);
     banner.appendChild(body);
+
+    /* #106 — compact Presentation legend: the SAME schema truth (observed /
+       inferred / unknown / notReached above) rendered as a one-line signal-
+       grammar key matching the schematic conductors exactly — solid observed,
+       dashed inferred, hatched unknown, dotted not-reached. Conditional items
+       only when the trace actually has them; no trace = honest empty label.
+       Which projection (legend vs full banner) is visible is decided purely by
+       body[data-view-mode] CSS — no state, no rerender, and the Inspect
+       collapsed/toggle state is never touched by switching modes. */
+    legend = el("ul", "confidence-legend");
+    legend.setAttribute("aria-label", "Signal legend");
+    function legendItem(sampleClass, label) {
+      var item = el("li", "confidence-legend-item");
+      var sample = el("span", "confidence-legend-sample " + sampleClass);
+      sample.setAttribute("aria-hidden", "true");
+      item.appendChild(sample);
+      item.appendChild(tx(label));
+      return item;
+    }
+    if (!trace) {
+      legend.appendChild(el("li", "confidence-legend-empty", "No trace loaded"));
+    } else {
+      legend.appendChild(legendItem("confidence-legend-sample--observed", "observed"));
+      legend.appendChild(legendItem("confidence-legend-sample--inferred", "inferred"));
+      if (unknown.length) {
+        legend.appendChild(legendItem("confidence-legend-sample--unknown", "unknown"));
+      }
+      if (notReached.length) {
+        legend.appendChild(legendItem("confidence-legend-sample--not-reached", "not reached"));
+      }
+    }
+    banner.appendChild(legend);
 
     if (!trace) {
       detail = CONFIDENCE_DETAIL_NO_TRACE;

--- a/tests/test_viewer_e2e.py
+++ b/tests/test_viewer_e2e.py
@@ -550,3 +550,134 @@ def test_trace_loader_360_no_overflow(tmp_path):
         page.locator("#traceLoaderSummary").click()
         assert page.evaluate("document.documentElement.scrollWidth") == 360
         browser.close()
+
+
+# --------------------------------------------------------------------------
+# #106 — compact Presentation confidence legend. ONE #confidenceBanner, two
+# CSS projections: Presentation = one-line signal-grammar strip (no title,
+# counts, toggle or body), Inspect = the unchanged full banner with counts,
+# Details toggle and expansion state preserved across mode switches.
+# --------------------------------------------------------------------------
+
+
+def test_confidence_legend_compact_in_presentation(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        assert page.locator(".confidence-legend").is_visible()
+        # full banner chrome leaves layout AND the focus/a11y tree
+        assert not page.locator(".confidence-head").is_visible()
+        assert not page.locator(".confidence-body").is_visible()
+        assert not page.locator(".confidence-toggle").is_visible()
+        assert page.locator(".confidence-toggle").get_attribute("aria-expanded") == "false"
+        height = page.evaluate(
+            "() => document.querySelector('#confidenceBanner').getBoundingClientRect().height"
+        )
+        assert height <= 38  # 28–34px strip (+ rounding tolerance)
+        samples = page.evaluate(
+            """() => {
+              const cs = s => getComputedStyle(document.querySelector(s));
+              return {
+                observed: cs('.confidence-legend-sample--observed').borderTopStyle,
+                inferred: cs('.confidence-legend-sample--inferred').borderTopStyle,
+              };
+            }"""
+        )
+        assert samples["observed"] == "solid"  # schematic conductor grammar
+        assert samples["inferred"] == "dashed"
+        # legend is labelled for AT
+        assert page.locator(".confidence-legend").get_attribute("aria-label") == "Signal legend"
+        browser.close()
+
+
+def test_confidence_legend_conditional_items(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+
+        def items(page):
+            return page.locator(".confidence-legend-item").all_inner_texts()
+
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(_viewer(tmp_path, "success").as_uri())
+        assert items(page) == ["observed", "inferred"]  # no unknown / not-reached lanes
+        page.goto(_viewer(tmp_path, "worker-unobserved").as_uri())
+        assert items(page) == ["observed", "inferred", "unknown"]  # 2 unknown lanes exist
+        unknown_sample = page.evaluate(
+            """() => {
+              const s = document.querySelector('.confidence-legend-sample--unknown');
+              return s && getComputedStyle(s).backgroundImage.includes('repeating-linear-gradient');
+            }"""
+        )
+        assert unknown_sample  # hatched/hollow sample grammar
+        page.goto(_viewer(tmp_path, "worker-fail").as_uri())
+        assert items(page) == ["observed", "inferred", "not reached"]  # downstream lanes stopped
+        dotted = page.evaluate(
+            """() => getComputedStyle(
+                 document.querySelector('.confidence-legend-sample--not-reached')
+               ).borderTopStyle"""
+        )
+        assert dotted == "dotted"
+        # no trace: the legend says so instead of implying grammar items
+        page.evaluate("window.Funcviz.clear()")
+        assert page.locator(".confidence-legend").text_content() == "No trace loaded"
+        browser.close()
+
+
+def test_confidence_legend_mode_switch_and_state(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "worker-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        attrs_before = page.evaluate(
+            "() => ({...document.querySelector('#confidenceBanner').dataset})"
+        )
+        page.locator("#inspectTab").click()
+        # Inspect: compact hidden, full banner exactly available
+        assert not page.locator(".confidence-legend").is_visible()
+        assert page.locator(".confidence-head").is_visible()
+        assert page.locator(".confidence-toggle").is_visible()
+        assert "not reached" in page.locator(".confidence-oneline").text_content()
+        assert not page.locator(".confidence-body-inner").is_visible()  # collapsed at rest
+        page.locator(".confidence-toggle").click()  # Details expands
+        page.wait_for_timeout(300)
+        assert page.locator(".confidence-body-inner").is_visible()
+        page.locator("#presentationTab").click()
+        # Presentation again: full content hidden, legend back
+        assert page.locator(".confidence-legend").is_visible()
+        assert not page.locator(".confidence-head").is_visible()
+        assert not page.locator(".confidence-body-inner").is_visible()
+        page.locator("#inspectTab").click()
+        # expansion state survived the round trip
+        assert page.locator("#confidenceBanner").get_attribute("data-collapsed") == "false"
+        assert page.locator(".confidence-toggle").get_attribute("aria-expanded") == "true"
+        assert page.locator(".confidence-body-inner").is_visible()
+        attrs_after = page.evaluate(
+            "() => ({...document.querySelector('#confidenceBanner').dataset})"
+        )
+        attrs_after["collapsed"] = attrs_before["collapsed"]  # only the intended toggle delta
+        assert attrs_after == attrs_before
+        browser.close()
+
+
+def test_confidence_legend_360_no_overflow(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "worker-unobserved")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 360, "height": 1600})
+        page.goto(html.as_uri())
+        assert page.locator(".confidence-legend").is_visible()
+        assert page.evaluate("document.documentElement.scrollWidth") == 360
+        legend_w = page.evaluate(
+            "() => document.querySelector('.confidence-legend').getBoundingClientRect().width"
+        )
+        assert legend_w <= 360
+        page.locator("#inspectTab").click()
+        assert page.evaluate("document.documentElement.scrollWidth") == 360
+        browser.close()


### PR DESCRIPTION
## Summary
- Presentation shows a 34px signal legend (solid observed, dashed inferred, hatch unknown, dotted not-reached) derived from the same lane arrays/data seams
- Inspect retains the complete confidence title/counts/Details/body and preserves expanded/collapsed state across mode switches
- conditional unknown/not-reached items, no-trace honesty, forced-colors, mobile fit

## Verification
- standard 162 passed / 23 skipped; Ruff, LSP, traces, Pages artifact
- viewer Chromium 22 passed (4 new compact/full mode contracts); Pages smoke 1
- all goldens 1440/360 console/network0, no overflow
- accessibility tree: named confidence region + labelled Signal legend in Presentation; full heading/counts/button in Inspect
- Oracle 94/100, no blockers; decorative samples hidden from AT before PR

Closes #106