### PR TITLE
feat(viewer): simplify Presentation replay progress (#107)

### DIFF
--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -1480,48 +1480,51 @@
   .ph-label .ph-state { color: var(--azure-blue-light); font-weight: 700; }
   .pres-handoff[data-evidenced="false"] .ph-label .ph-state { color: var(--text-faint); font-weight: 400; }
 
-  /* ---- scrubber — signal-trace graticule, display-only real ms (#97, #99) */
+  /* ---- scrubber — simplified Presentation time context (#97, #99, #107) - */
+  /* #107 — no graticule, no bounds, no note: one neutral progress line, an
+     azure fill, and a restrained current marker. Exact end/axis labels and
+     tick contracts belong to the Inspect axis. DOM/ids/data attrs/JS (and the
+     view-independent progress hook) are untouched — pure restyle. */
   .pres-scrubber-wrap {
     background: var(--schem-ink);
     border: 1px solid var(--border-strong);
     border-top: 1px solid var(--schem-hair); /* hairline under the flow band */
     border-radius: 0 0 var(--schem-radius) var(--schem-radius);
-    padding: var(--sp-3) var(--sp-4);
+    padding: var(--sp-2) var(--sp-4) var(--sp-3); /* #107 — slimmer band */
     box-shadow: none;
   }
   #presentationScrubber { pointer-events: none; }
-  .pres-scrubber-track { /* graticule: minor ticks every 10%, major every 50% */
-    position: relative; height: 10px;
+  .pres-scrubber-track { /* plain neutral line — every tick gradient removed (#107) */
+    position: relative; height: 4px;
     background-color: var(--bg-inset);
-    background-image:
-      repeating-linear-gradient(90deg, rgba(50, 49, 48, .22) 0 1px, transparent 1px 10%),
-      repeating-linear-gradient(90deg, rgba(50, 49, 48, .4) 0 1px, transparent 1px 50%);
-    border: 1px solid var(--border);
+    background-image: none;
+    border: 1px solid var(--border-strong);
     border-radius: var(--schem-radius);
   }
-  .pres-scrubber-fill { /* flat azure phosphor, no gradient */
+  .pres-scrubber-fill { /* simple azure fill */
     position: absolute; left: 0; top: 0; bottom: 0; width: 0;
     border-radius: 0;
     background: var(--azure-blue);
   }
-  .pres-scrubber-thumb { /* caliper cursor — hairline blade, no glowing dot */
-    position: absolute; top: 50%; left: 0; width: 4px; height: 16px;
-    margin: -8px 0 0 -2px; border-radius: 1px;
+  .pres-scrubber-thumb { /* restrained current-position cursor, no glow */
+    position: absolute; top: 50%; left: 0; width: 3px; height: 12px;
+    margin: -6px 0 0 -2px; border-radius: 1px;
     background: var(--azure-blue-light); border: none;
     box-shadow: none;
   }
-  .pres-scrubber-row {
-    display: flex; align-items: baseline; justify-content: space-between;
+  .pres-scrubber-row { /* elapsed centered under the line (#107) */
+    display: flex; align-items: baseline; justify-content: center;
     gap: var(--sp-3); margin-top: var(--sp-2);
     font-family: var(--mono); font-size: 11px; color: var(--text-faint);
   }
   #presentationScrubberElapsed {
     color: var(--azure-blue-light); font-weight: 700; font-size: 12px;
   }
-  .pres-scrubber-note {
-    margin: var(--sp-2) 0 0; font-size: 10.5px; font-style: italic;
-    color: var(--text-faint);
-  }
+  /* #107 — start/end bounds and the explanatory sentence are Presentation
+     chrome now removed from the a11y/layout tree; the DOM + JS text seams
+     (e.g. #presentationScrubberEnd) remain backward-compatible */
+  .pres-scrubber-bound,
+  .pres-scrubber-note { display: none; }
 
   /* ---- presentation source — the application code probe (#97, #99) ----- */
   /* Same #57/#58 window/content. #99 — when application code is executing,
@@ -1598,6 +1601,9 @@
     .pres-handoff[data-active="true"] .ph-pulse { background: Highlight; }
     .playhead { background: Highlight; }
     .pres-scrubber-fill { background: Highlight; }
+    /* #107 — simplified scrubber stays visible with system colors */
+    .pres-scrubber-track { background: Canvas; border-color: CanvasText; }
+    .pres-scrubber-thumb { background: Highlight; }
     /* #105 — disclosure chevron + focus stay visible with system colors */
     .trace-loader summary::after { border-color: CanvasText; }
     .trace-loader summary:focus-visible { outline: 2px solid Highlight; outline-offset: -2px; }

--- a/tests/test_viewer_e2e.py
+++ b/tests/test_viewer_e2e.py
@@ -681,3 +681,137 @@ def test_confidence_legend_360_no_overflow(tmp_path):
         page.locator("#inspectTab").click()
         assert page.evaluate("document.documentElement.scrollWidth") == 360
         browser.close()
+
+
+# --------------------------------------------------------------------------
+# #107 — simplified Presentation scrubber: one neutral progress line, azure
+# fill, restrained marker; no graticule/bounds/note. Inspect axis contracts
+# untouched. DOM/ids/data attrs/JS unchanged (pure CSS restyle).
+# --------------------------------------------------------------------------
+
+
+def test_simple_scrubber_plain_line_no_chrome(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        for _ in range(4):
+            page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(250)
+        state = page.evaluate(
+            """() => {
+              const q = s => document.querySelector(s);
+              const track = q('.pres-scrubber-track');
+              const elapsed = q('#presentationScrubberElapsed');
+              const tr = track.getBoundingClientRect();
+              const er = elapsed.getBoundingClientRect();
+              return {
+                bgImage: getComputedStyle(track).backgroundImage,
+                trackH: tr.height,
+                boundsInLayout: q('#presentationScrubberEnd').offsetParent !== null ||
+                                q('#presentationScrubberStart').offsetParent !== null,
+                noteDisplay: getComputedStyle(q('.pres-scrubber-note')).display,
+                elapsedVisible: elapsed.offsetParent !== null,
+                elapsedText: elapsed.textContent,
+                centerDelta: Math.abs((er.left + er.width / 2) - (tr.left + tr.width / 2)),
+              };
+            }"""
+        )
+        assert state["bgImage"] == "none"  # no tick gradients at all
+        assert state["trackH"] <= 6  # simple 3–4px visual line
+        assert state["boundsInLayout"] is False  # exact axis belongs to Inspect
+        assert state["noteDisplay"] == "none"
+        assert state["elapsedVisible"] is True
+        assert state["elapsedText"] == "+272 ms"  # real ms context remains
+        assert state["centerDelta"] <= 2  # centered under the line
+        browser.close()
+
+
+def test_simple_scrubber_progress_hooks_and_failure_clamp(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "invocation-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        for _ in range(8):
+            if page.locator("#presentationNextBtn").is_disabled():
+                break
+            page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(250)
+        state = page.evaluate(
+            """() => ({
+              elapsedMs: document.querySelector('#presentationScrubber').dataset.elapsedMs,
+              progressPct: document.querySelector('#presentationScrubber').dataset.progressPct,
+              fillW: document.querySelector('#presentationScrubberFill').style.width,
+              thumbL: document.querySelector('#presentationScrubberThumb').style.left,
+            })"""
+        )
+        # view-independent progress hook + forensic failure clamp (#97) intact
+        assert state["elapsedMs"] == "285"
+        assert float(state["progressPct"]) == 100.0
+        assert state["fillW"] == "100%"
+        assert state["thumbL"] == "100%"
+        browser.close()
+
+
+def test_simple_scrubber_inspect_axis_unchanged(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.locator("#presentationNextBtn").click()  # enter the run (stream view)
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(300)
+        axis = page.evaluate(
+            """() => {
+              const ends = [...document.querySelectorAll('#lanes .axis-end')]
+                .map(e => e.textContent.trim());
+              const tickLabels = [...document.querySelectorAll('#lanes .axis-tick-label')]
+                .map(e => e.textContent.trim());
+              const firstTrack = getComputedStyle(document.querySelector('#lanes .lane-track'));
+              return {
+                ends, tickLabels,
+                trackGrid: firstTrack.backgroundImage,
+                explicitGridlines: document.querySelectorAll('#lanes .lane-gridline').length,
+              };
+            }"""
+        )
+        assert axis["ends"] == ["end +294 ms"]  # exact end label stays in Inspect
+        assert "+0" in axis["tickLabels"]  # start tick still on the shared axis
+        assert axis["tickLabels"]  # compressed ticks render on the axis
+        # #53 gridline grammar intact: uniform gradient OR explicit per-track
+        # gridlines when a compressible gap suppresses the gradient
+        assert "repeating-linear-gradient" in axis["trackGrid"] or axis["explicitGridlines"] > 0
+        assert page.evaluate("window.Funcviz.compressionBands()") >= 1
+        browser.close()
+
+
+def test_simple_scrubber_viewports_no_overflow(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        for width in (1440, 720, 360):
+            page = browser.new_page(
+                viewport={"width": width, "height": 1600 if width == 360 else 1000}
+            )
+            page.goto(html.as_uri())
+            for _ in range(2):
+                page.locator("#presentationNextBtn").click()
+            assert page.evaluate("document.documentElement.scrollWidth") == width
+            assert page.locator(".pres-scrubber-track").is_visible()
+            if width <= 899:
+                order = page.evaluate(
+                    """() => {
+                      const top = s => document.querySelector(s).getBoundingClientRect().top;
+                      return top('#presentationSource') < top('#presentationScrubber');
+                    }"""
+                )
+                assert order is True  # pinned mobile order: source before scrubber
+            page.close()
+        browser.close()


### PR DESCRIPTION
## Summary
- remove Presentation minor/major graticule ticks and formal start/end labels
- keep a compact Azure progress line, restrained cursor, and centered real elapsed time
- reduce the scrubber band from 84px to 51px
- preserve every scrubber ID/data seam and keep the full Inspect axis/compression untouched

## Verification
- standard: 162 passed / 27 skipped; Ruff, LSP, traces, Pages artifact
- Chromium viewer E2E: 26 passed (4 new scrubber/Inspect-axis/mobile contracts)
- Pages smoke: 1 passed
- all goldens 1440/360 console/network0, no overflow
- Oracle 94/100, no blockers

Closes #107