### PR TITLE
feat(viewer): connected Source Probe replaces Presentation Application actor (#122)

### DIFF
--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -1075,7 +1075,7 @@
     border-top: 1px dashed var(--border);
     border-bottom: 1px dashed var(--border);
   }
-  .source-code { list-style: none; margin: 0; padding: 0; font-family: var(--mono); font-size: 12.5px; line-height: 1.65; }
+  .source-code { min-width: max-content; list-style: none; margin: 0; padding: 0; font-family: var(--mono); font-size: 12.5px; line-height: 1.65; }
   .source-line { display: flex; align-items: center; height: var(--src-line-h); white-space: pre; padding: 0 var(--sp-4); }
   .source-line:hover { background: rgba(0, 0, 0, .03); }
   .line-num {
@@ -1331,10 +1331,10 @@
   }
   .pres-sequence-viewport:focus-visible { outline: 2px solid var(--text); outline-offset: -2px; }
   .pres-flow {
-    counter-reset: actor; /* #99 — U1..U4 designators via CSS counter */
+    counter-reset: actor; /* #99 — U1..U3 designators via CSS counter */
     display: grid;
-    grid-template-columns: repeat(4, minmax(160px, 1fr));
-    min-width: 720px; /* #117 — canvas floor; only the viewport scrolls */
+    grid-template-columns: repeat(3, minmax(200px, 1fr));
+    min-width: 660px; /* #122 — 3 runtime columns; probe port lives at the worker edge */
     background-color: var(--schem-chassis);
     background-image:
       linear-gradient(var(--schem-sheet) 1px, transparent 1px),
@@ -1364,7 +1364,6 @@
   .pres-actor[data-presentation-lane="client"] { --actor-accent: var(--client); }
   .pres-actor[data-presentation-lane="host"] { --actor-accent: var(--host); }
   .pres-actor[data-presentation-lane="python-worker"] { --actor-accent: var(--worker); }
-  .pres-actor[data-presentation-lane="application"] { --actor-accent: var(--app); }
   .pres-actor::before { /* terminal rail on the signal spine — scaleX only, never reflows */
     content: ""; position: absolute; left: 0; top: -1px; bottom: -1px; width: 3px;
     background: var(--actor-accent);
@@ -1400,7 +1399,7 @@
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     transition: color .15s ease;
   }
-  .pres-actor-title::before { /* U1..U4 — schematic component designator */
+  .pres-actor-title::before { /* U1..U3 — schematic component designator */
     content: "U" counter(actor);
     margin-right: var(--sp-2);
     color: var(--text-faint);
@@ -1564,15 +1563,23 @@
      Connector grammar matches the schematic: observed solid, inferred dashed
      (worker→app always inferred), states future/active/complete; the failure
      row carries the fault mark and is always the last row. */
-  .sequence-rows { grid-column: 1 / -1; position: relative; }
-  .sequence-lifeline {
-    position: absolute; top: 0; bottom: 0; width: 1px;
-    background: var(--border-strong);
+   .sequence-rows { grid-column: 1 / -1; position: relative; }
+   .sequence-lifeline {
+     position: absolute; top: 0; bottom: 0; width: 1px;
+     background: var(--border-strong);
+   }
+  /* #122 — probe port at the worker column's right edge: the boundary jack
+     every application row terminates at (structure, not a fourth lane) */
+  .sequence-probe-jack {
+    position: absolute; bottom: 0; width: 10px; height: 10px;
+    margin-left: -5px; border-radius: 1px;
+    border: 2px dashed var(--border-strong);
+    background: var(--schem-chassis);
   }
   .sequence-row {
     position: relative;
     display: grid;
-    grid-template-columns: repeat(4, minmax(160px, 1fr));
+    grid-template-columns: repeat(3, minmax(200px, 1fr));
     min-height: 60px;
   }
   .sequence-message-line {
@@ -1634,6 +1641,37 @@
   .sequence-row[data-failure="true"][data-kind="handoff"] .sequence-message-line {
     border-top-color: var(--fail-strong);
   }
+  /* #122 — Source Probe boundary rows: entry connector is a short inferred
+     dashed stub worker→port; exit/interior app events are probe markers only
+     (no invented arrow back). Return-to-runtime rows stay dashed inferred —
+     never an observed application response. */
+  .sequence-row[data-kind="source-boundary"] .sequence-probe-line {
+    border-top-style: dashed;
+    border-top-color: var(--schem-line);
+  }
+  .sequence-row[data-kind="source-boundary"][data-state="active"] .sequence-probe-line {
+    border-top-color: var(--schem-lit);
+    border-top-width: 3px;
+  }
+  .sequence-row[data-kind="source-boundary"][data-state="active"] .sequence-probe-arrow {
+    border-left-color: var(--schem-lit);
+  }
+  .sequence-probe-arrow { border-left-color: var(--schem-line); }
+  .sequence-probe-marker {
+    border: 2px dashed var(--schem-line);
+    background: var(--schem-chassis);
+    width: 10px; height: 10px; margin: -5px 0 0 -5px;
+  }
+  .sequence-row[data-kind="source-boundary"][data-state="active"] .sequence-probe-marker {
+    border-color: var(--schem-lit);
+    background: var(--schem-lit);
+  }
+  .sequence-row[data-boundary-phase="exit"] .sequence-probe-marker { border-radius: 50%; }
+  .sequence-row[data-from-probe="true"] .sequence-message-line { border-top-style: dashed; }
+  .sequence-row[data-from-probe="true"] .sequence-message-label::after {
+    content: " after source probe";
+    color: var(--text-faint); font-weight: 400;
+  }
   .sequence-packet { /* current-signal packet — replay transition, not latency */
     position: absolute; top: 58%; left: var(--seq-from, 0);
     width: 7px; height: 9px; margin-top: -4.5px;
@@ -1641,7 +1679,8 @@
     clip-path: polygon(0 0, 100% 50%, 0 100%);
     opacity: 0; pointer-events: none;
   }
-  .sequence-row[data-state="active"][data-kind="handoff"] .sequence-packet {
+  .sequence-row[data-state="active"][data-kind="handoff"] .sequence-packet,
+  .sequence-row[data-state="active"][data-kind="source-boundary"][data-boundary-phase="enter"] .sequence-packet {
     opacity: 1;
     animation: sequence-travel .9s linear infinite;
   }
@@ -1653,6 +1692,7 @@
   @media (prefers-reduced-motion: reduce) {
     .sequence-packet { animation: none !important; opacity: 0 !important; }
     .sequence-row[data-state="active"] .sequence-message-line { border-top-width: 4px; }
+    .sequence-row[data-state="active"][data-kind="source-boundary"] .sequence-probe-line { border-top-width: 4px; }
   }
 
   /* ---- scrubber — simplified Presentation time context (#97, #99, #107) - */
@@ -1711,6 +1751,39 @@
     border: 1px solid var(--border-strong);
     border-radius: var(--schem-radius);
     box-shadow: none;
+    position: relative; /* #122 — probe rail anchors to the drawer top */
+  }
+  /* #122 — decorative probe rail: dashed vertical cue continuing from the
+     worker-edge port down to the drawer; positioning set by JS from the
+     actual worker column edge (--probe-rail-left). No timing meaning. */
+  .pres-source-drawer::before {
+    content: ""; position: absolute; top: calc(-1 * var(--sp-3)); bottom: auto;
+    left: var(--probe-rail-left, 90%); width: 0; height: var(--sp-3);
+    border-left: 2px dashed var(--schem-line);
+    pointer-events: none;
+  }
+  .pres-source-drawer[data-source-status="active"]::before { border-left-color: var(--azure-blue); }
+  .pres-source-drawer[data-source-status="unknown"]::before { border-left-style: dotted; }
+  .pres-source-drawer[data-source-status="not-reached"]::before { border-left-style: dotted; border-left-color: var(--border-strong); }
+  /* #122 — probe status chip on the summary: visible accessible status */
+  .pres-source-drawer-sub { font-weight: 400; letter-spacing: 0; text-transform: none; color: var(--text-faint); }
+  .pres-source-drawer-status {
+    flex: none;
+    font-size: 9.5px; font-weight: 700; letter-spacing: 1px;
+    padding: 1px 7px; border-radius: var(--schem-radius);
+    border: 1px solid var(--border-strong); color: var(--text-faint);
+  }
+  .pres-source-drawer[data-source-status="active"] .pres-source-drawer-status {
+    color: #FFFFFF; background: var(--azure-blue); border-color: transparent;
+  }
+  .pres-source-drawer[data-source-status="reached"] .pres-source-drawer-status {
+    color: var(--ok-strong); border-color: rgba(16, 124, 16, .4);
+  }
+  .pres-source-drawer[data-source-status="unknown"] .pres-source-drawer-status {
+    color: var(--worker); border-color: rgba(161, 92, 0, .4);
+  }
+  .pres-source-drawer[data-source-status="not-reached"] .pres-source-drawer-status {
+    color: var(--text-faint); border-style: dashed;
   }
   .pres-source-drawer summary {
     display: flex; align-items: center; gap: var(--sp-3);
@@ -1757,11 +1830,6 @@
   }
   #presentationSource[data-app-active="true"] .source-head {
     background: rgba(0, 120, 212, .08);
-  }
-  /* probe counterpart on the schematic: the Application terminal's
-     downstream edge lights when user code is the current signal */
-  #presentationFlow .pres-actor[data-presentation-lane="application"][data-active="true"] {
-    border-right: 3px solid var(--azure-blue);
   }
   #presentationSource .source-dot { border-radius: 1px; } /* square jack, presentation-scoped */
 
@@ -1825,6 +1893,10 @@
     .trace-loader summary:focus-visible { outline: 2px solid Highlight; outline-offset: -2px; }
     /* #117 — sequence lifelines/arrows/active/failure stay visible */
     .sequence-lifeline { background: CanvasText; }
+    .sequence-probe-jack { border-color: CanvasText; }
+    .sequence-probe-arrow { border-left-color: CanvasText; }
+    .sequence-probe-marker { border-color: CanvasText; }
+    .pres-source-drawer::before { border-left-color: CanvasText; }
     .sequence-message-line { border-top-color: CanvasText; }
     .sequence-message-arrow--right { border-left-color: CanvasText; }
     .sequence-message-arrow--left { border-right-color: CanvasText; }
@@ -1875,7 +1947,11 @@
     .confidence-banner-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
     .confidence-oneline { grid-column: 1 / -1; width: 100%; }
     .pres-layout { padding: var(--sp-3) var(--sp-3) var(--sp-4); }
-    #presentationEvent { font-size: 18px; min-height: 48px; }
+    #presentationEvent {
+      min-height: 48px; font-size: 17px;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      overflow-wrap: normal; word-break: normal;
+    }
     /* #108 — narrow-column replay invariance: handoff lines and the pre-play
        meta hint wrap to two lines at ~300px, so both get a two-line reserve
        and the story band never shifts between replay states */
@@ -1998,8 +2074,8 @@
          scrollable viewport (keyboard focusable) whose inner canvas holds a
          4-column actor grid; #presentationFlow keeps its ID and remains the
          element JS renders into -->
-<div class="pres-sequence-viewport" tabindex="0" role="group" aria-label="Runtime sequence diagram — client, functions host, python worker, application; horizontally scrollable on narrow screens">
-      <section class="pres-flow" id="presentationFlow" aria-label="Runtime flow — client, functions host, python worker, application"></section>
+    <div class="pres-sequence-viewport" tabindex="0" role="group" aria-label="Runtime sequence diagram — client, functions host, python worker; application source probe below; horizontally scrollable on narrow screens">
+      <section class="pres-flow" id="presentationFlow" aria-label="Runtime flow — client, functions host, python worker; application source probe below"></section>
     </div>
 
     <!-- #117 — Source Probe drawer: native disclosure, open by default so
@@ -2008,7 +2084,8 @@
          buildSourceModel/renderSourceInto pair as Inspect -->
     <details id="presentationSourceDrawer" class="pres-source-drawer" open>
       <summary id="presentationSourceDrawerSummary">
-        <span class="pres-source-drawer-title">Source</span>
+        <span class="pres-source-drawer-title">Source Probe <span class="pres-source-drawer-sub">· your function code</span></span>
+        <span class="pres-source-drawer-status" id="presentationSourceStatus">NOT REACHED</span>
         <span class="pres-source-drawer-file" id="presentationSourceFileLabel"></span>
         <span class="pres-source-drawer-hint pres-source-drawer-hint--collapse">Collapse</span>
         <span class="pres-source-drawer-hint pres-source-drawer-hint--expand">Expand</span>
@@ -2306,12 +2383,17 @@
   /* Presentation (default) and Inspect are pure projections of the SAME
      state above; viewMode survives trace loads and never resets anything. */
   var viewMode = "presentation"; /* "presentation" | "inspect" */
+  /* #122 — Presentation projects THREE runtime actors: client | host |
+     python-worker. The application lane is NOT an actor here — it is the
+     Source Probe boundary below the sequence (Inspect keeps all four lanes,
+     LANE_ORDER untouched). */
   var PRESENTATION_ACTORS = [
     { lane: "client", title: "CLIENT", role: "caller / HTTP" },
     { lane: "host", title: "FUNCTIONS HOST", role: "trigger / dispatch" },
     { lane: "python-worker", title: "PYTHON WORKER", role: "language worker / gRPC" },
-    { lane: "application", title: "APPLICATION", role: "your function code" }
   ];
+  var PRESENTATION_SEQUENCE_COLS = ["client", "host", "python-worker"];
+  var SOURCE_PROBE_PCT = 92; /* worker column right-edge probe port, % of canvas */
   /* the three fixed adjacent handoffs, in chain order */
   var PRESENTATION_HANDOFFS = [
     { key: "client-host", a: "client", b: "host" },
@@ -4254,8 +4336,12 @@
           "Re-run with elevated worker logging (see host.json) to observe the worker/application lanes."));
       } else {
         ph.appendChild(tx("Source text was not embedded in this trace. "));
-        ph.appendChild(el("code", null, model.fileRaw));
-        ph.appendChild(tx(" was recorded as the source file, but local file loading is unavailable from file://."));
+        if (model.hasSourceFile) {
+          ph.appendChild(el("code", null, model.fileRaw));
+          ph.appendChild(tx(" was recorded as the source file, but local file loading is unavailable from file://."));
+        } else {
+          ph.appendChild(tx("No source file was recorded for this run."));
+        }
       }
       body.appendChild(ph);
       return body;
@@ -4327,6 +4413,50 @@
         : model.mode === "window" ? (model.hasSourceFile ? model.file : "embedded source")
         : model.hasSourceFile ? model.file : "Source unavailable";
     }
+  }
+
+  /* #122 — Source Probe runtime status, derived ONLY from the application
+     lane metadata + the current clamped event (no duplicate truth; source
+     TEXT availability is a separate concern handled by the panel body):
+     active while the current event is application code executing, else
+     reached/unknown/not-reached straight from lanes.application.status. */
+  function applyPresentationSourceStatus(trace, ev) {
+    var drawer = document.getElementById("presentationSourceDrawer");
+    var statusLabel = document.getElementById("presentationSourceStatus");
+    var laneMeta = ((trace && trace.lanes) || {}).application || {};
+    var laneStatus = laneMeta.status || "not-reached";
+    var active = !!(ev && ev.lane === "application");
+    var status = active ? "active"
+      : (laneStatus === "reached" || laneStatus === "failed-here") ? "reached"
+      : laneStatus === "unknown" ? "unknown" : "not-reached";
+    if (drawer) drawer.setAttribute("data-source-status", status);
+    if (statusLabel) {
+      statusLabel.textContent = {
+        active: "ACTIVE", reached: "REACHED", unknown: "UNKNOWN", "not-reached": "NOT REACHED"
+      }[status] || status;
+    }
+  }
+
+  /* #122 — decorative probe rail: a dashed vertical cue in the gap between
+     the sequence viewport and the source drawer, aligned under the WORKER
+     column's right edge (where the probe port is). Presentation-only; no
+     timing meaning; repositioned on resize via the existing listener. */
+  function updateSourceProbeRail() {
+    var drawer = document.getElementById("presentationSourceDrawer");
+    var viewport = document.querySelector(".pres-sequence-viewport");
+    if (!drawer || !viewport || typeof drawer.style.setProperty !== "function") return;
+    var vRect = viewport.getBoundingClientRect();
+    var worker = document.querySelector(
+      '#presentationFlow .pres-actor[data-presentation-lane="python-worker"]');
+    var x = null;
+    var wRect = null;
+    if (worker) {
+      wRect = worker.getBoundingClientRect();
+      x = (wRect.right - vRect.left) - 24; /* just inside the worker edge port */
+    }
+    if (x == null || !isFinite(x)) x = vRect.width * 0.9;
+    x = Math.max(16, Math.min(x, vRect.width - 16)); /* stay visible when scrolled */
+    drawer.style.setProperty("--probe-rail-left", x + "px");
   }
 
   /* ---------------- #97 — Presentation projection ----------------------- */
@@ -4477,6 +4607,24 @@
      is always inferred). Nothing past the failure boundary is included —
      post-failure nodes stay Inspect-only forensic evidence. No fabricated
      return/request rows, no symmetry synthesis. */
+  /* ---------------- #117/#122 — sequence projection ----------------------
+     A pure viewer-only projection: one row per replayable event (the SAME
+     replayableEvents() boundary the transport obeys), in sequence order,
+     including untimed events. #122: the application lane is not a fourth
+     column — its events project onto the Source Probe boundary at the
+     worker column's right-edge port. An app ENTRY (e.g.
+     ApplicationFunctionStarted) draws a short inferred dashed connector
+     worker→probe; app COMPLETION and any other app event is a probe
+     marker (no invented arrow back); the next runtime event after app
+     activity is a return-to-runtime row sourced at the worker (never an
+     "observed app response" — it stays inferred). Nothing past the failure
+     boundary is included; no symmetry synthesis. */
+  function presentationBoundaryPhase(ev) {
+    if (ev.event === "ApplicationFunctionStarted") return "enter";
+    if (ev.event === "ApplicationFunctionCompleted") return "exit";
+    return "in";
+  }
+
   function buildPresentationSequenceRows() {
     var boundary = replayableEvents();
     var rows = [];
@@ -4485,27 +4633,63 @@
     var i = 0;
     for (i = 0; i < boundary.events.length; i++) {
       ev = boundary.events[i];
-      rows.push({
-        eventId: ev.id,
-        sequence: ev.sequence != null ? ev.sequence : i,
-        sourceLane: prev ? prev.lane : ev.lane,
-        targetLane: ev.lane,
-        direction: !prev ? "" : (prev.lane === ev.lane ? "" :
-          (LANE_ORDER.indexOf(ev.lane) > LANE_ORDER.indexOf(prev.lane) ? "forward" : "response")),
-        confidence: prev ? classifyConnector(prev, ev) : (ev.confidence || ""),
-        label: ev.event || "Unnamed event",
-        elapsedMs: typeof ev.elapsedMs === "number" ? ev.elapsedMs : null,
-        kind: !prev ? "origin" : (prev.lane === ev.lane ? "same-lane" : "handoff"),
-        evidence: ev.confidence || null,
-        failure: !!(boundary.failureEvent && boundary.failureEvent.id === ev.id)
-      });
+      if (ev.lane === "application") {
+        rows.push({
+          eventId: ev.id,
+          sequence: ev.sequence != null ? ev.sequence : i,
+          sourceLane: prev && prev.lane !== "application" ? prev.lane : "python-worker",
+          targetLane: "application",
+          direction: prev && prev.lane !== "application" ? "forward" : "",
+          confidence: "inferred", /* the source boundary is always inferred */
+          label: ev.event || "Unnamed event",
+          elapsedMs: typeof ev.elapsedMs === "number" ? ev.elapsedMs : null,
+          kind: "source-boundary",
+          boundaryPhase: presentationBoundaryPhase(ev),
+          evidence: ev.confidence || null,
+          failure: !!(boundary.failureEvent && boundary.failureEvent.id === ev.id)
+        });
+      } else if (prev && prev.lane === "application") {
+        /* return to runtime from the probe: the ACTUAL next event, sourced
+           at the worker (execution owner), always inferred — never an
+           observed application response */
+        rows.push({
+          eventId: ev.id,
+          sequence: ev.sequence != null ? ev.sequence : i,
+          sourceLane: "python-worker",
+          targetLane: ev.lane,
+          direction: "response",
+          confidence: "inferred",
+          label: ev.event || "Unnamed event",
+          elapsedMs: typeof ev.elapsedMs === "number" ? ev.elapsedMs : null,
+          kind: "handoff",
+          fromProbe: true,
+          evidence: ev.confidence || null,
+          failure: !!(boundary.failureEvent && boundary.failureEvent.id === ev.id)
+        });
+      } else {
+        rows.push({
+          eventId: ev.id,
+          sequence: ev.sequence != null ? ev.sequence : i,
+          sourceLane: prev ? prev.lane : ev.lane,
+          targetLane: ev.lane,
+          direction: !prev ? "" : (prev.lane === ev.lane ? "" :
+            (LANE_ORDER.indexOf(ev.lane) > LANE_ORDER.indexOf(prev.lane) ? "forward" : "response")),
+          confidence: prev ? classifyConnector(prev, ev) : (ev.confidence || ""),
+          label: ev.event || "Unnamed event",
+          elapsedMs: typeof ev.elapsedMs === "number" ? ev.elapsedMs : null,
+          kind: !prev ? "origin" : (prev.lane === ev.lane ? "same-lane" : "handoff"),
+          evidence: ev.confidence || null,
+          failure: !!(boundary.failureEvent && boundary.failureEvent.id === ev.id)
+        });
+      }
       prev = ev;
     }
     return rows;
   }
 
   function sequenceLaneCenterPct(lane) {
-    return (LANE_ORDER.indexOf(lane) + 0.5) * 25;
+    if (lane === "application") return SOURCE_PROBE_PCT; /* worker right-edge port */
+    return (PRESENTATION_SEQUENCE_COLS.indexOf(lane) + 0.5) * (100 / PRESENTATION_SEQUENCE_COLS.length);
   }
 
   function buildSequenceRowDom(row) {
@@ -4529,7 +4713,36 @@
     node.setAttribute("data-state", "future");
     if (row.failure) node.setAttribute("data-failure", "true");
     if (row.direction) node.setAttribute("data-direction", row.direction);
-    if (row.kind === "handoff") {
+    if (row.fromProbe) node.setAttribute("data-from-probe", "true");
+    if (row.kind === "source-boundary") {
+      node.setAttribute("data-boundary-phase", row.boundaryPhase);
+      if (row.boundaryPhase === "enter") {
+        /* short inferred dashed connector worker-center → probe port */
+        line = el("span", "sequence-message-line sequence-probe-line");
+        line.setAttribute("aria-hidden", "true");
+        line.style.left = Math.min(fromPct, toPct) + "%";
+        line.style.width = Math.abs(toPct - fromPct) + "%";
+        arrow = el("span", "sequence-message-arrow sequence-message-arrow--right sequence-probe-arrow");
+        arrow.setAttribute("aria-hidden", "true");
+        arrow.style.left = "calc(" + Math.max(fromPct, toPct) + "% - 7px)";
+        packet = el("span", "sequence-packet");
+        packet.setAttribute("aria-hidden", "true");
+        node.style.setProperty("--seq-from", fromPct + "%");
+        node.style.setProperty("--seq-to", toPct + "%");
+        node.appendChild(line);
+        node.appendChild(arrow);
+        node.appendChild(packet);
+      } else {
+        /* completion / interior app event: probe marker only — never an
+           invented arrow back out of the boundary */
+        marker = el("span", "sequence-event-marker sequence-probe-marker");
+        marker.setAttribute("aria-hidden", "true");
+        marker.style.left = toPct + "%";
+        node.appendChild(marker);
+      }
+      label.style.right = "calc(" + (100 - toPct) + "% + 10px)";
+      meta.style.right = "calc(" + (100 - toPct) + "% + 10px)";
+    } else if (row.kind === "handoff") {
       line = el("span", "sequence-message-line");
       line.setAttribute("aria-hidden", "true");
       line.style.left = Math.min(fromPct, toPct) + "%";
@@ -4549,8 +4762,9 @@
       node.appendChild(line);
       node.appendChild(arrow);
       node.appendChild(packet);
-      /* label anchored at the source side of the connector */
-      if (LANE_ORDER.indexOf(row.sourceLane) <= 1) {
+      /* label anchored at the source side of the connector (3-col grid:
+         client/host sources anchor left, worker sources anchor right) */
+      if (PRESENTATION_SEQUENCE_COLS.indexOf(row.sourceLane) <= 1) {
         label.style.left = "calc(" + Math.min(fromPct, toPct) + "% + 10px)";
         meta.style.left = "calc(" + Math.min(fromPct, toPct) + "% + 10px)";
       } else {
@@ -4563,7 +4777,7 @@
       marker.style.left = toPct + "%";
       node.appendChild(marker);
       /* marker label: to the right on the left half, to the left on the right */
-      if (LANE_ORDER.indexOf(row.targetLane) <= 1) {
+      if (PRESENTATION_SEQUENCE_COLS.indexOf(row.targetLane) <= 1) {
         label.style.left = "calc(" + toPct + "% + 10px)";
         meta.style.left = "calc(" + toPct + "% + 10px)";
       } else {
@@ -4593,8 +4807,9 @@
      var status = null;
      var card = null;
      var chip = null;
-     var rowsBox = null;
-     var lifeline = null;
+      var rowsBox = null;
+      var lifeline = null;
+      var jack = null;
     flow.textContent = "";
     presentationDomain = { t0: scale.t0, span: Math.max(0, endMs - scale.t0) };
     for (a = 0; a < PRESENTATION_ACTORS.length; a++) {
@@ -4617,20 +4832,27 @@
       h = PRESENTATION_HANDOFFS[a]; /* hidden #97 state model — still updated for back-compat */
       if (h) flow.appendChild(buildPresentationHandoff(h, presentationHandoffPlan[h.key]));
     }
-    /* #117 — sequence canvas: lifelines + one row per replayable event */
+    /* #117/#122 — sequence canvas: THREE lifelines + one row per replayable
+       event; the application lane projects onto the worker-edge probe port */
     presentationSequenceRows = buildPresentationSequenceRows();
     rowsBox = el("div", "sequence-rows");
     rowsBox.setAttribute("aria-hidden", "true"); /* rows mirror story copy; one live story is enough */
-    for (a = 0; a < LANE_ORDER.length; a++) {
+    for (a = 0; a < PRESENTATION_SEQUENCE_COLS.length; a++) {
       lifeline = el("span", "sequence-lifeline");
-      lifeline.style.left = ((a + 0.5) * 25) + "%";
+      lifeline.style.left = ((a + 0.5) * (100 / PRESENTATION_SEQUENCE_COLS.length)) + "%";
       rowsBox.appendChild(lifeline);
     }
+    jack = el("span", "sequence-probe-jack");
+    jack.setAttribute("aria-hidden", "true");
+    jack.style.left = SOURCE_PROBE_PCT + "%";
+    rowsBox.appendChild(jack);
     for (a = 0; a < presentationSequenceRows.length; a++) {
       rowsBox.appendChild(buildSequenceRowDom(presentationSequenceRows[a]));
     }
     flow.appendChild(rowsBox);
     renderPresentationSource(trace);
+    applyPresentationSourceStatus(trace, null); /* #122 — probe status from lane truth */
+    updateSourceProbeRail(); /* #122 — decorative rail tracks the worker column edge */
     startLabel = document.getElementById("presentationScrubberStart");
     endLabel = document.getElementById("presentationScrubberEnd");
     startLabel.textContent = scale.t0 + " ms";
@@ -4687,6 +4909,7 @@
       applyPresentationSequence(ev);
       applyPresentationStory(ev, trans, ended, outcome, forensicEv);
       if (src) src.setAttribute("data-app-active", appActive ? "true" : "false");
+      applyPresentationSourceStatus(currentTrace, ev); /* #122 — probe status follows the same event */
     }
     updatePresentationScrubber();
   }
@@ -4800,7 +5023,10 @@
   function applyPresentationActors(ev) {
     var cards = document.querySelectorAll("#presentationFlow .pres-actor");
     var i = 0;
-    var lane = ev ? ev.lane : null;
+    /* #122 — with no application actor, the Python Worker is the execution
+       OWNER while application code runs (the Source Probe carries the
+       active-code signal via data-source-status) */
+    var lane = ev ? (ev.lane === "application" ? "python-worker" : ev.lane) : null;
     for (i = 0; i < cards.length; i++) {
       cards[i].setAttribute("data-active",
         cards[i].getAttribute("data-presentation-lane") === lane ? "true" : "false");
@@ -4875,6 +5101,8 @@
     var backward = false;
     var stepNo = 0;
     var conf = null;
+    var storyFromLabel = "";
+    var storyToLabel = "";
     /* #97 forensic seam — the selection is post-failure Inspect evidence */
     story.setAttribute("data-forensic", forensicEv ? "true" : "false");
     story.setAttribute("data-phase", prePlay ? "pre-play" : ended ? "ended" : "running");
@@ -4904,21 +5132,38 @@
         : "no trace loaded";
     } else {
       eventEl.textContent = ev.event || "Unnamed event";
+      /* #122 — Presentation names the probe boundary, not a fourth actor:
+         app targets read "Source Probe · user code"; app selections name
+         the worker as execution owner */
+      storyFromLabel = LANE_LABELS[trans && trans.from.lane] || (trans && trans.from.lane) || "";
+      storyToLabel = LANE_LABELS[trans && trans.to.lane] || (trans && trans.to.lane) || "";
+      if (trans && trans.to.lane === "application") {
+        storyToLabel = "Source Probe \u00b7 user code";
+        if (trans.from.lane === "application" || !trans.from.lane) storyFromLabel = "Python Worker";
+      }
+      if (trans && trans.from.lane === "application" && trans.to.lane !== "application") {
+        storyFromLabel = "Source Probe \u00b7 user code";
+      }
       if (trans && trans.from.lane !== trans.to.lane) {
         /* direction wording from the actual pair — a pair moving back up
            the chain is a response return; never an invented RPC name */
         backward = LANE_ORDER.indexOf(trans.to.lane) < LANE_ORDER.indexOf(trans.from.lane);
         handoffEl.textContent = "";
         handoffEl.appendChild(tx((backward ? "response return" : "control handoff") + " \u00b7 " +
-          (LANE_LABELS[trans.from.lane] || trans.from.lane) + " "));
+          storyFromLabel + " "));
         handoffEl.appendChild(el("span", "ph-dir-glyph", "\u2192"));
-        handoffEl.appendChild(tx(" " + (LANE_LABELS[trans.to.lane] || trans.to.lane) +
+        handoffEl.appendChild(tx(" " + storyToLabel +
           " \u00b7 " + classifyConnector(trans.from, trans.to)));
       } else {
         /* same-lane consecutive steps (or an untimed selection) name the
-           active component — they are not handoffs */
-        handoffEl.textContent = "in " + (LANE_LABELS[ev.lane] || ev.lane || "?") +
-          " \u2014 " + (LANE_ROLE_SUBTITLES[ev.lane] || "");
+           active component — they are not handoffs; application steps run
+           in the Source Probe with the worker as owner */
+        if (ev.lane === "application") {
+          handoffEl.textContent = "in Source Probe \u2014 your function code (executed by Python Worker)";
+        } else {
+          handoffEl.textContent = "in " + (LANE_LABELS[ev.lane] || ev.lane || "?") +
+            " \u2014 " + (LANE_ROLE_SUBTITLES[ev.lane] || "");
+        }
       }
       stepNo = (ev.sequence != null ? ev.sequence : indexOfEvent(ev.id)) + 1;
       conf = ev.confidence === "inferred" ? "inferred" : "observed";
@@ -5551,11 +5796,14 @@
      Connectors (#54) re-derive from the same post-layout anchors, and the
      compressed axis (#53) re-measures the track width and repositions its
      deferred geometry against the new px mapping. */
-  var staggerResizeTimer = null;
-  window.addEventListener("resize", function () {
-    if (staggerResizeTimer != null) window.clearTimeout(staggerResizeTimer);
-    staggerResizeTimer = window.setTimeout(relayoutInspectGeometry, 120);
-  });
+   var staggerResizeTimer = null;
+   window.addEventListener("resize", function () {
+     if (staggerResizeTimer != null) window.clearTimeout(staggerResizeTimer);
+     staggerResizeTimer = window.setTimeout(function () {
+       relayoutInspectGeometry();
+       updateSourceProbeRail(); /* #122 — decorative probe rail tracks the worker edge */
+     }, 120);
+   });
 
   /* selection interactions — delegated on #lanes (click + keyboard).
      Manual selection always pauses autoplay first (#7), then reuses
@@ -5606,6 +5854,11 @@
     presentationSourceOpen: function () {
       var drawer = document.getElementById("presentationSourceDrawer");
       return !!(drawer && drawer.open);
+    },
+    /* #122 — Source Probe runtime status (headless assertion hook) */
+    presentationSourceStatus: function () {
+      var drawer = document.getElementById("presentationSourceDrawer");
+      return drawer ? drawer.getAttribute("data-source-status") : null;
     },
     presentationSequenceRowIds: function () {
       return presentationSequenceRows.map(function (row) { return row.eventId; });

--- a/tests/test_viewer_e2e.py
+++ b/tests/test_viewer_e2e.py
@@ -39,7 +39,7 @@ def test_view_switch_preserves_selection_and_playback_position(tmp_path):
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         page.goto(html.as_uri())
         assert page.locator("body").get_attribute("data-view-mode") == "presentation"
-        assert page.locator("[data-presentation-lane]").count() == 4
+        assert page.locator("[data-presentation-lane]").count() == 3  # #122: app = Source Probe
         page.locator("#presentationNextBtn").click()
         page.locator("#presentationNextBtn").click()
         page.locator("#presentationNextBtn").click()
@@ -251,7 +251,7 @@ def test_visual_actor_terminals_flat_small_radius_no_shadow(tmp_path):
         title = page.evaluate(
             "() => document.querySelector('.pres-actor .pres-actor-title').textContent"
         )
-        assert title in {"CLIENT", "FUNCTIONS HOST", "PYTHON WORKER", "APPLICATION"}
+        assert title in {"CLIENT", "FUNCTIONS HOST", "PYTHON WORKER"}  # #122: no app actor
         browser.close()
 
 
@@ -1039,7 +1039,7 @@ def test_sequence_header_geometry_and_stack_order(tmp_path):
                        srcTop: src.top, scrubTop: scrub.top };
             }"""
         )
-        assert geo["actors"] == ["client", "host", "python-worker", "application"]
+        assert geo["actors"] == ["client", "host", "python-worker"]  # #122: app = Source Probe
         assert geo["xs"] == sorted(geo["xs"])  # left→right lane order
         assert max(geo["ys"]) - min(geo["ys"]) <= 1  # one header row
         assert geo["vpW"] >= geo["storyW"] - 2  # sequence spans the full column
@@ -1065,7 +1065,6 @@ def test_sequence_long_status_does_not_wrap_actor_titles(tmp_path):
             "CLIENT",
             "FUNCTIONS HOST",
             "PYTHON WORKER",
-            "APPLICATION",
         ]
         assert all(item["oneLine"] and item["fits"] for item in titles)
         browser.close()
@@ -1103,7 +1102,10 @@ def test_sequence_rows_match_replayable_boundary_per_golden(tmp_path):
               .filter(a => a.getAttribute('data-status') === 'unknown')
               .map(a => a.getAttribute('data-presentation-lane'))"""
         )
-        assert set(headers) == {"python-worker", "application"}
+        assert set(headers) == {"python-worker"}  # #122: app truth lives on the probe
+        assert (
+            page.evaluate("window.Funcviz.presentationSourceStatus()") == "unknown"
+        )  # not the actor
         browser.close()
 
 
@@ -1131,10 +1133,13 @@ def test_sequence_row_shapes_and_grammar(tmp_path):
         by_id = {r["id"]: r for r in rows}
         assert by_id["e0"]["kind"] == "origin" and by_id["e0"]["hasMarker"]
         assert by_id["e1"]["dir"] == "forward"  # request left→right from actual lanes
+        # #122 — e3 is the probe ENTRY: worker→port, inferred dashed connector
+        assert by_id["e3"]["kind"] == "source-boundary" and by_id["e3"]["hasLine"]
         assert by_id["e3"]["conf"] == "inferred" and by_id["e3"]["lineStyle"] == "dashed"
         assert by_id["e2"]["conf"] == "observed" and by_id["e2"]["lineStyle"] == "solid"
-        assert by_id["e4"]["kind"] == "same-lane" and by_id["e4"]["hasMarker"]
-        assert not by_id["e4"]["hasLine"]  # marker never becomes an invented arrow
+        # e4 is the probe EXIT: marker only — never an invented arrow back
+        assert by_id["e4"]["kind"] == "source-boundary" and by_id["e4"]["hasMarker"]
+        assert not by_id["e4"]["hasLine"]
         assert by_id["e5"]["dir"] == "response" and by_id["e6"]["dir"] == "response"
         assert "+251 ms" in by_id["e1"]["meta"] and "inferred" in by_id["e1"]["meta"]
         browser.close()
@@ -1172,7 +1177,7 @@ def test_sequence_replay_states_sync_with_actors_and_packet(tmp_path):
         assert packet["activeRows"] == 1
         assert packet["packets"] == 1  # only the active handoff row carries the packet
         assert packet["anim"] == "sequence-travel"
-        assert packet["actor"] == "application"  # actor follows the same clamped event
+        assert packet["actor"] == "python-worker"  # #122: worker owns execution during app rows
         for _ in range(3):  # run to the end
             page.locator("#presentationNextBtn").click()
         page.wait_for_timeout(200)
@@ -1599,4 +1604,199 @@ def test_shared_shell_no_overflow_and_360_rows(tmp_path):
         )
         assert readable["noClip"] is True  # inspect group fits the 360 reserve
         assert readable["statusVisible"] is True
+        browser.close()
+
+
+# --------------------------------------------------------------------------
+# #122 — Source Probe boundary: THREE runtime actors + worker-connected
+# probe. Application events project onto the probe (never a fourth lane);
+# the worker owns execution during app rows; probe status derives from the
+# application lane truth + current event only.
+# --------------------------------------------------------------------------
+
+
+def test_probe_boundary_three_actors_no_fourth_lane(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        canvas = page.evaluate(
+            """() => ({
+              actors: [...document.querySelectorAll('#presentationFlow .pres-actor')]
+                .map(a => a.getAttribute('data-presentation-lane')),
+              lifelines: document.querySelectorAll('.sequence-lifeline').length,
+              lifelinePos: [...document.querySelectorAll('.sequence-lifeline')]
+                .map(l => l.style.left),
+              jack: !!document.querySelector('.sequence-probe-jack'),
+              jackPos: document.querySelector('.sequence-probe-jack').style.left,
+              aria: document.querySelector('.pres-sequence-viewport').getAttribute('aria-label'),
+              cols: getComputedStyle(document.querySelector('.pres-flow'))
+                .gridTemplateColumns.split(' ').length,
+            })"""
+        )
+        assert canvas["actors"] == ["client", "host", "python-worker"]
+        assert canvas["lifelines"] == 3  # no fourth lane center
+        assert canvas["lifelinePos"] == ["16.6667%", "50%", "83.3333%"]
+        assert canvas["jack"] is True  # the probe port replaces the lane
+        assert "source probe below" in canvas["aria"]
+        assert canvas["cols"] == 3
+        # the hidden #97 handoff model for worker→application stays updated
+        page.locator("#presentationNextBtn").click()
+        for _ in range(3):
+            page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(150)
+        seam = page.locator('[data-presentation-handoff="python-worker-application"]')
+        assert seam.count() == 1
+        assert seam.get_attribute("data-complete") == "true"
+        browser.close()
+
+
+def test_probe_boundary_replay_owner_and_status_per_step(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        expected = [
+            ("reached", "client"),
+            ("reached", "host"),
+            ("reached", "python-worker"),
+            ("active", "python-worker"),
+            ("active", "python-worker"),  # app start + complete
+            ("reached", "host"),
+            ("reached", "client"),
+        ]
+        for step, (probe, actor) in enumerate(expected, start=1):
+            page.locator("#presentationNextBtn").click()
+            page.wait_for_timeout(80)
+            got = (
+                page.evaluate("window.Funcviz.presentationSourceStatus()"),
+                page.evaluate(
+                    """() => document.querySelector('.pres-actor[data-active="true"]')
+                      .getAttribute('data-presentation-lane')"""
+                ),
+            )
+            assert got == (probe, actor), (step, got, (probe, actor))
+        # no "observed app response": the return row stays inferred + provenance cue
+        ret = page.evaluate(
+            """() => {
+              const r = document.querySelector('.sequence-row[data-event-id="e5"]');
+              return { conf: r.getAttribute('data-confidence'),
+                       fromProbe: r.getAttribute('data-from-probe'),
+                       src: r.getAttribute('data-source-lane'),
+                       phase: document.querySelector('.sequence-row[data-event-id="e3"]')
+                         .getAttribute('data-boundary-phase') };
+            }"""
+        )
+        assert ret == {
+            "conf": "inferred",
+            "fromProbe": "true",
+            "src": "python-worker",
+            "phase": "enter",
+        }
+        return_copy = page.evaluate(
+            """() => {
+              const label = document.querySelector(
+                '.sequence-row[data-from-probe="true"] .sequence-message-label');
+              return getComputedStyle(label, '::after').content;
+            }"""
+        )
+        assert "after source probe" in return_copy
+        browser.close()
+
+
+def test_probe_boundary_status_vs_content_availability(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        # worker-fail: lane not-reached AND source text absent — two dimensions
+        page.goto(_viewer(tmp_path, "worker-fail").as_uri())
+        assert page.evaluate("window.Funcviz.presentationSourceStatus()") == "not-reached"
+        assert page.locator("#presentationSourceFileLabel").text_content() == "Source unavailable"
+        assert "NOT REACHED" in page.locator("#presentationSourceStatus").text_content()
+        assert "No source file was recorded" in page.locator("#presentationSource").text_content()
+        # invocation-fail: app lane reached (code ran), host failed later
+        page.goto(_viewer(tmp_path, "invocation-fail").as_uri())
+        assert page.evaluate("window.Funcviz.presentationSourceStatus()") == "reached"
+        assert page.locator("#presentationSourceFileLabel").text_content() == "function_app.py"
+        # worker-unobserved: application lane unknown
+        page.goto(_viewer(tmp_path, "worker-unobserved").as_uri())
+        assert page.evaluate("window.Funcviz.presentationSourceStatus()") == "unknown"
+        assert "UNKNOWN" in page.locator("#presentationSourceStatus").text_content()
+        # drawer summary reads as the probe boundary
+        summary = page.locator("#presentationSourceDrawerSummary").text_content()
+        assert "Source Probe" in summary and "your function code" in summary
+        browser.close()
+
+
+def test_probe_boundary_inspect_application_lane_intact(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.locator("#presentationNextBtn").click()
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(300)
+        inspect = page.evaluate(
+            """() => ({
+              lanes: [...document.querySelectorAll('#lanes .lane')]
+                .map(l => l.getAttribute('data-lane-name')),
+              appNodes: document.querySelectorAll(
+                '#lanes .lane[data-lane-name="application"] .event').length,
+              connectors: window.Funcviz.connectorCount(),
+            })"""
+        )
+        assert inspect["lanes"] == ["client", "host", "python-worker", "application"]
+        assert inspect["appNodes"] >= 2  # application events live on in Inspect
+        assert inspect["connectors"] >= 1
+        browser.close()
+
+
+def test_probe_boundary_responsive_360(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "worker-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 360, "height": 1800})
+        page.goto(html.as_uri())
+        assert page.evaluate("document.documentElement.scrollWidth") == 360
+        vp = page.evaluate(
+            """() => {
+              const v = document.querySelector('.pres-sequence-viewport');
+              return { client: v.clientWidth, scroll: v.scrollWidth,
+                       canvas: document.querySelector('#presentationFlow')
+                         .getBoundingClientRect().width };
+            }"""
+        )
+        assert vp["scroll"] > vp["client"]  # 660px canvas floor scrolls internally
+        assert vp["canvas"] >= 660
+        rail = page.evaluate(
+            """() => getComputedStyle(
+                 document.querySelector('#presentationSourceDrawer'), '::before').left"""
+        )
+        assert rail.endswith("px")  # JS-positioned rail stays inside the visible column
+        browser.close()
+
+
+def test_probe_boundary_mobile_event_and_source_remain_readable(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 360, "height": 1800})
+        page.goto(html.as_uri())
+        for _ in range(4):
+            page.locator("#presentationNextBtn").click()
+        event = page.locator("#presentationEvent")
+        assert event.text_content() == "ApplicationFunctionStarted"
+        assert event.evaluate("el => el.scrollHeight <= el.clientHeight + 1")
+        source = page.locator("#presentationSource .source-window")
+        assert source.evaluate("el => el.scrollWidth > el.clientWidth")
+        assert page.evaluate("document.documentElement.scrollWidth") == 360
         browser.close()


### PR DESCRIPTION
## Summary
- Presentation now has exactly three runtime actors: Client, Functions Host, Python Worker
- preserve every application event as a Source Probe boundary row instead of discarding trace truth
- worker→probe remains inferred/dashed; app completion is marker-only; host continuation is inferred `after source probe`, never an observed app RPC
- Source Probe exposes active/reached/unknown/not-reached independently from source-text availability
- Inspect retains the full Application lane, events, intervals, stack, source, and forensic evidence
- improve 360px readability: event title stays one line and source code scrolls inside its window

## Verification
- standard 162 passed / 53 skipped; Ruff, LSP, traces, Pages artifact
- Chromium viewer E2E 52 passed; Pages smoke 1
- all golden row IDs/counts unchanged; failure cutoffs exact; worker-unobserved/worker-fail invent no app rows
- 1440/720/360 no page overflow; source probe and internal source scroll verified
- Oracle 92/100, no blockers; wording/a11y/stale-selector nits fixed before PR

Closes #122