### PR TITLE
feat(viewer): shared Evidence and Source layers (#125)

### DIFF
--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -421,18 +421,53 @@
      layout — timeline + source panel
      ============================================================ */
   .layout {
-    display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(340px, 1fr);
+    display: grid; grid-template-columns: minmax(0, 1fr); /* #125 — full-width timeline; evidence/source are shared layers below */
     gap: var(--sp-5); padding: var(--sp-4) var(--sp-5) var(--sp-5);
     max-width: 1440px; margin: 0 auto; align-items: start;
     /* #120 — top inset normalized to .pres-layout so mode content starts at
        the same y under the shared transport shell (horizontal geometry and
-       internal column widths unchanged) */
+        internal column widths unchanged) */
+   }
+  /* #125 — .inspector-rail is gone: step detail / error summary / call stack
+     live in #sharedEvidenceLayer and the source panel in #sharedSourceDrawer
+     (rules below); the timeline owns the full frame. */
+
+  /* ============================================================
+     #125 — shared Evidence + Source layers below the active view.
+     Same max-width/gutter as the active shell in both modes; evidence is a
+     3-column grid at wide widths and stacks below 900px. The source drawer
+     reuses the #117/#122 probe drawer styling (class pres-source-drawer).
+     ============================================================ */
+  #sharedEvidenceLayer {
+    max-width: 1440px; margin: var(--sp-4) auto 0;
+    padding: 0 var(--sp-5);
   }
-  /* right column of .layout — step detail (#6) stacked above the source panel */
-  .inspector-rail {
-    display: flex; flex-direction: column; gap: var(--sp-5);
-    min-width: 0; align-self: stretch;
+  .shared-evidence-grid {
+    /* minmax(0, ·) — fr tracks must share the row even when a card holds a
+       long failure message; the message wraps inside its card instead of
+       blowing out the track (the auto-min trap) */
+    display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1fr);
+    gap: var(--sp-4); align-items: start;
   }
+  @media (max-width: 900px) {
+    .shared-evidence-grid { grid-template-columns: minmax(0, 1fr); }
+  }
+  /* Presentation compacts evidence via CSS ONLY: correlation ID rows and the
+     raw-log block recede; semantic event/elapsed/confidence, error message/
+     component and stack frames always stay */
+  body[data-view-mode="presentation"] #sharedEvidenceLayer .detail-id,
+  body[data-view-mode="presentation"] #sharedEvidenceLayer .raw-log-label,
+  body[data-view-mode="presentation"] #sharedEvidenceLayer .raw-log { display: none; }
+  /* the shared source drawer is bottom full-width in both modes; no sticky;
+     the max() margin trick keeps the shell gutter at narrow widths and
+     centers under the 1440 cap at wide ones */
+  #sharedSourceDrawer {
+    max-width: 1440px;
+    margin: var(--sp-3) max(var(--sp-5), calc((100% - 1440px) / 2)) 0;
+  }
+  #sharedSourceDrawer .source-panel { position: static; }
+  /* probe rail terminates at the shared drawer top (Presentation only) */
+  body[data-view-mode="inspect"] #sharedSourceDrawer::before { display: none; }
 
   /* ============================================================
      durations — three separately-labeled chips (R4: never collapse)
@@ -1209,17 +1244,16 @@
      padding: var(--sp-4) var(--sp-5) var(--sp-2);
      align-items: start;
      grid-template-columns: minmax(0, 1fr);
-     /* #120 — transport area removed: the strip lives in the shared shell
-        above both views; internal band positions are unchanged */
-     grid-template-areas:
-       "story"
-       "flow"
-       "source"
-       "scrubber";
+    /* #120/#125 — transport lives in the shared shell above; the source
+       probe lives in the shared source layer below; this layout is
+       story → sequence → progress only */
+    grid-template-areas:
+      "story"
+      "flow"
+      "scrubber";
    }
    .pres-story { grid-area: story; }
    .pres-sequence-viewport { grid-area: flow; }
-   .pres-source-drawer { grid-area: source; }
    .pres-scrubber-wrap { grid-area: scrubber; }
 
   /* ---- current-step story (#97) — instrument readout ------------------ */
@@ -1811,27 +1845,23 @@
     border-right: 2px solid currentColor; border-bottom: 2px solid currentColor;
     transform: rotate(45deg);
   }
-  .pres-source-drawer[open] summary::after { transform: rotate(225deg); }
-  .pres-source-drawer[open] summary { border-radius: var(--schem-radius) var(--schem-radius) 0 0; }
-  /* the probe panel itself: static, seamless inside the drawer; probe rail
-     + app-active grammar from #99/#104 unchanged */
-  .pres-source-drawer #presentationSource {
+   .pres-source-drawer[open] summary::after { transform: rotate(225deg); }
+   .pres-source-drawer[open] summary { border-radius: var(--schem-radius) var(--schem-radius) 0 0; }
+  /* #125 — the ONE shared source panel inside the drawer: static, seamless;
+     the #99/#104 app-active probe grammar applies in Presentation framing */
+  #sharedSourceDrawer .source-panel {
     position: static; margin: 0;
     border: none; border-top: 1px solid var(--border);
     border-radius: 0;
-  }
-  #presentationSource {
-    align-self: start;
     transition: border-color .2s ease, box-shadow .2s ease;
   }
-  #presentationSource[data-app-active="true"] {
+  body[data-view-mode="presentation"] #sourcePanel[data-app-active="true"] {
     border-color: rgba(0, 120, 212, .6);
     box-shadow: inset 3px 0 0 var(--azure-blue); /* probe rail jack */
   }
-  #presentationSource[data-app-active="true"] .source-head {
+  body[data-view-mode="presentation"] #sourcePanel[data-app-active="true"] .source-head {
     background: rgba(0, 120, 212, .08);
   }
-  #presentationSource .source-dot { border-radius: 1px; } /* square jack, presentation-scoped */
 
   /* ---- presentation transport — flat command strip (#97, #99) ---------- */
   .pres-transport {
@@ -1865,7 +1895,7 @@
     .pres-handoff[data-active="true"][data-direction="forward"] .ph-arrow { border-top-width: 9px; }
     .pres-handoff[data-active="true"][data-direction="response"] .ph-arrow { border-bottom-width: 9px; }
     .pres-actor, .pres-actor::before, .pres-actor::after,
-    .pres-handoff, .ph-line, #presentationSource { transition: none; }
+    .pres-handoff, .ph-line, #sharedSourceDrawer .source-panel { transition: none; }
   }
 
   /* #99 — forced colors (Windows High Contrast): states map to system
@@ -2078,22 +2108,9 @@
       <section class="pres-flow" id="presentationFlow" aria-label="Runtime flow — client, functions host, python worker; application source probe below"></section>
     </div>
 
-    <!-- #117 — Source Probe drawer: native disclosure, open by default so
-         the compact source window stays visible; #presentationSource keeps
-         its ID/class/data-app-active and is rendered by the SAME shared
-         buildSourceModel/renderSourceInto pair as Inspect -->
-    <details id="presentationSourceDrawer" class="pres-source-drawer" open>
-      <summary id="presentationSourceDrawerSummary">
-        <span class="pres-source-drawer-title">Source Probe <span class="pres-source-drawer-sub">· your function code</span></span>
-        <span class="pres-source-drawer-status" id="presentationSourceStatus">NOT REACHED</span>
-        <span class="pres-source-drawer-file" id="presentationSourceFileLabel"></span>
-        <span class="pres-source-drawer-hint pres-source-drawer-hint--collapse">Collapse</span>
-        <span class="pres-source-drawer-hint pres-source-drawer-hint--expand">Expand</span>
-        <span class="pres-source-drawer-caret" aria-hidden="true"></span>
-      </summary>
-      <aside id="presentationSource" class="source-panel" data-app-active="false" aria-label="Application code — presentation"></aside>
-    </details>
-
+    <!-- #125 — the Source Probe drawer migrated to the SHARED source layer
+         below both views (#sharedSourceDrawer); this layout now ends at the
+         progress band -->
     <section class="pres-scrubber-wrap" aria-label="Replay progress">
       <!-- display-only real-ms progress (not a formal time axis): fill is the
            real-domain ratio elapsed/sweepEnd; stepping is via the transport -->
@@ -2132,8 +2149,18 @@
     <h2 class="vh">Runtime lanes</h2>
     <div class="lanes" id="lanes"></div>
   </section>
+  <!-- #125 — the former .inspector-rail is fully removed: step detail /
+       error summary / call stack / source panel live in the SHARED evidence
+       + source layers below both views, and the timeline is full-width -->
+</main>
+</div>
 
-  <aside class="inspector-rail" aria-label="Trace inspection">
+<!-- #125 — SHARED Evidence layer: Step Detail | Error Summary | Call Stack,
+     one always-mounted DOM below the active view. The same nodes serve both
+     modes (IDs unchanged); Presentation compacts low-level detail via CSS
+     only, Inspect shows full forensic detail. -->
+<section id="sharedEvidenceLayer" aria-label="Selected event evidence">
+  <div class="shared-evidence-grid">
     <section id="stepDetail" class="step-detail" aria-labelledby="stepDetailTitle" aria-live="polite"></section>
     <!-- #62 (spec §7 band E) — per-trace error summary: failure message +
          failing component, or an EXPLICIT reserved empty row (§11.11 — the
@@ -2147,10 +2174,26 @@
           updateStackPanel(); data-stack-lanes carries the active lane keys
           (comma-joined) for headless assertion. -->
     <section id="stackPanel" class="stack-panel" aria-labelledby="stackPanelTitle" data-stack-lanes=""></section>
-    <aside class="source-panel" id="sourcePanel" aria-label="Application source panel"></aside>
-  </aside>
-</main>
-</div>
+  </div>
+</section>
+
+<!-- #125 — SHARED Source layer: ONE visible source DOM node (#sourcePanel)
+     rendered by the single renderSource()/buildSourceModel() truth. Framing
+     text changes by mode (Presentation: Source Probe · your function code;
+     Inspect: Application source); content, file label, runtime status and
+     provenance are identical. Open state persists across mode switches and
+     replay; default open. -->
+<details id="sharedSourceDrawer" class="pres-source-drawer shared-source-drawer" open>
+  <summary id="sharedSourceDrawerSummary">
+    <span class="pres-source-drawer-title" id="sharedSourceTitle"><span id="sharedSourceTitleMain">Source Probe</span><span class="pres-source-drawer-sub" id="sharedSourceTitleSub"> · your function code</span></span>
+    <span class="pres-source-drawer-status" id="sharedSourceStatus">NOT REACHED</span>
+    <span class="pres-source-drawer-file" id="sharedSourceFileLabel"></span>
+    <span class="pres-source-drawer-hint pres-source-drawer-hint--collapse">Collapse</span>
+    <span class="pres-source-drawer-hint pres-source-drawer-hint--expand">Expand</span>
+    <span class="pres-source-drawer-caret" aria-hidden="true"></span>
+  </summary>
+  <aside class="source-panel" id="sourcePanel" aria-label="Application source panel"></aside>
+</details>
 
 <footer class="app-footer">
   funcviz static viewer · rendered locally from an embedded trace (no network) · <span id="footerMeta"></span>
@@ -4214,12 +4257,12 @@
   /* #97 — renderSource split into a PURE model + shared DOM builder so the
      Presentation source renders the exact same #57/#58 interpretation
      (window math, focus precedence, confidence wording) without duplic it:
-     buildSourceModel(trace) → {file, status, reason, mode, window, lines,
-     range, failureLine, definitionConfidence}; renderSourceInto(panel,
-     model) paints head + reason + body. renderSource (Inspect, #sourcePanel)
-     and renderPresentationSource (#presentationSource) are two projections
-     of one model; only renderSource maintains sourceWindowState (the
-     Funcviz.sourceWindow() hook state). */
+      buildSourceModel(trace) → {file, status, reason, mode, window, lines,
+      range, failureLine, definitionConfidence}; renderSourceInto(panel,
+      model) paints head + reason + body. #125 — renderSource is the ONE
+      renderer into the shared #sourcePanel (the former Presentation
+      duplicate is gone); it maintains sourceWindowState (the
+      Funcviz.sourceWindow() hook state) and the shared drawer file label. */
   function buildSourceModel(trace) {
     var app = (trace && trace.application) || {};
     var laneMeta = ((trace && trace.lanes) || {}).application || {};
@@ -4396,18 +4439,14 @@
     panel.appendChild(buildSourceBody(model));
   }
 
+  /* #125 — ONE source truth: buildSourceModel + renderSourceInto feed the
+     shared #sourcePanel; the shared drawer summary (file label) derives from
+     the SAME model. The old Presentation duplicate renderer is gone. */
   function renderSource(trace) {
     var model = buildSourceModel(trace);
     sourceWindowState = model.window;
     renderSourceInto(document.getElementById("sourcePanel"), model);
-  }
-
-  function renderPresentationSource(trace) {
-    var model = buildSourceModel(trace);
-    renderSourceInto(document.getElementById("presentationSource"), model);
-    /* #117 — the drawer summary carries the current file label from the SAME
-       source model (no second parse); no-source stays honestly unlabeled */
-    var fileLabel = document.getElementById("presentationSourceFileLabel");
+    var fileLabel = document.getElementById("sharedSourceFileLabel");
     if (fileLabel) {
       fileLabel.textContent = !trace ? "no trace loaded"
         : model.mode === "window" ? (model.hasSourceFile ? model.file : "embedded source")
@@ -4415,14 +4454,15 @@
     }
   }
 
-  /* #122 — Source Probe runtime status, derived ONLY from the application
-     lane metadata + the current clamped event (no duplicate truth; source
-     TEXT availability is a separate concern handled by the panel body):
-     active while the current event is application code executing, else
-     reached/unknown/not-reached straight from lanes.application.status. */
+  /* #122/#125 — shared Source Probe runtime status, derived ONLY from the
+     application lane metadata + the current clamped event (no duplicate
+     truth; source TEXT availability is a separate concern handled by the
+     panel body): active while the current event is application code
+     executing, else reached/unknown/not-reached straight from
+     lanes.application.status. Drives #sharedSourceDrawer + its status chip. */
   function applyPresentationSourceStatus(trace, ev) {
-    var drawer = document.getElementById("presentationSourceDrawer");
-    var statusLabel = document.getElementById("presentationSourceStatus");
+    var drawer = document.getElementById("sharedSourceDrawer");
+    var statusLabel = document.getElementById("sharedSourceStatus");
     var laneMeta = ((trace && trace.lanes) || {}).application || {};
     var laneStatus = laneMeta.status || "not-reached";
     var active = !!(ev && ev.lane === "application");
@@ -4441,21 +4481,26 @@
      the sequence viewport and the source drawer, aligned under the WORKER
      column's right edge (where the probe port is). Presentation-only; no
      timing meaning; repositioned on resize via the existing listener. */
+  /* #122/#125 — decorative probe rail: a dashed vertical cue at the SHARED
+     source drawer's top, aligned under the WORKER column's right edge (where
+     the sequence probe port is). Presentation-only (hidden by mode CSS in
+     Inspect); no timing meaning; repositioned on resize. */
   function updateSourceProbeRail() {
-    var drawer = document.getElementById("presentationSourceDrawer");
+    var drawer = document.getElementById("sharedSourceDrawer");
     var viewport = document.querySelector(".pres-sequence-viewport");
     if (!drawer || !viewport || typeof drawer.style.setProperty !== "function") return;
     var vRect = viewport.getBoundingClientRect();
+    var dRect = drawer.getBoundingClientRect();
     var worker = document.querySelector(
       '#presentationFlow .pres-actor[data-presentation-lane="python-worker"]');
     var x = null;
     var wRect = null;
     if (worker) {
       wRect = worker.getBoundingClientRect();
-      x = (wRect.right - vRect.left) - 24; /* just inside the worker edge port */
+      x = (wRect.right - dRect.left) - 24; /* under the worker edge port */
     }
-    if (x == null || !isFinite(x)) x = vRect.width * 0.9;
-    x = Math.max(16, Math.min(x, vRect.width - 16)); /* stay visible when scrolled */
+    if (x == null || !isFinite(x)) x = dRect.width * 0.9;
+    x = Math.max(16, Math.min(x, dRect.width - 16)); /* stay visible when scrolled */
     drawer.style.setProperty("--probe-rail-left", x + "px");
   }
 
@@ -4487,6 +4532,7 @@
     var banner = document.getElementById("confidenceBanner");
     var confidenceSlot = document.getElementById(presActive
       ? "presentationConfidenceSlot" : "inspectConfidenceSlot");
+    var sharedTitle = null;
     if (banner && confidenceSlot && banner.parentElement !== confidenceSlot) {
       confidenceSlot.appendChild(banner);
     }
@@ -4502,6 +4548,15 @@
        status to the accessibility tree. */
     document.getElementById("outcomeChip").setAttribute("aria-hidden",
       presActive ? "true" : "false");
+    /* #125 — shared source framing text follows the mode (text only; never
+       a rerender, never a state reset; content/status stay identical) */
+    sharedTitle = document.getElementById("sharedSourceTitleMain");
+    if (sharedTitle) sharedTitle.textContent = presActive ? "Source Probe" : "Application source";
+    sharedTitle = document.getElementById("sharedSourceTitleSub");
+    if (sharedTitle) {
+      sharedTitle.textContent = presActive ? " \u00b7 your function code" : "";
+      sharedTitle.hidden = !presActive;
+    }
     if (!presActive && !prePlay) {
       window.requestAnimationFrame(relayoutInspectGeometry);
     }
@@ -4850,9 +4905,8 @@
       rowsBox.appendChild(buildSequenceRowDom(presentationSequenceRows[a]));
     }
     flow.appendChild(rowsBox);
-    renderPresentationSource(trace);
-    applyPresentationSourceStatus(trace, null); /* #122 — probe status from lane truth */
-    updateSourceProbeRail(); /* #122 — decorative rail tracks the worker column edge */
+    applyPresentationSourceStatus(trace, null); /* #122/#125 — shared probe status from lane truth */
+    updateSourceProbeRail(); /* #122/#125 — decorative rail tracks the worker column edge */
     startLabel = document.getElementById("presentationScrubberStart");
     endLabel = document.getElementById("presentationScrubberEnd");
     startLabel.textContent = scale.t0 + " ms";
@@ -4884,7 +4938,7 @@
     var j = 0;
     var entry = null;
     var key = null;
-    var src = document.getElementById("presentationSource");
+    var src = document.getElementById("sourcePanel"); /* #125 — the ONE shared source node */
     for (j = 0; j < PRESENTATION_HANDOFFS.length; j++) {
       key = PRESENTATION_HANDOFFS[j].key;
       entry = presentationHandoffPlan[key];
@@ -5850,14 +5904,24 @@
       var details = document.getElementById("traceLoader");
       return !!(details && details.open);
     },
-    /* #117 — sequence/source disclosure state hooks (headless assertions) */
+    /* #117 — sequence/source disclosure state hooks (headless assertions).
+       #125 — both map to the SHARED source drawer; the old names stay as
+       compatibility aliases, sharedSourceOpen/Status are additive. */
+    sharedSourceOpen: function () {
+      var drawer = document.getElementById("sharedSourceDrawer");
+      return !!(drawer && drawer.open);
+    },
     presentationSourceOpen: function () {
-      var drawer = document.getElementById("presentationSourceDrawer");
+      var drawer = document.getElementById("sharedSourceDrawer");
       return !!(drawer && drawer.open);
     },
     /* #122 — Source Probe runtime status (headless assertion hook) */
+    sharedSourceStatus: function () {
+      var drawer = document.getElementById("sharedSourceDrawer");
+      return drawer ? drawer.getAttribute("data-source-status") : null;
+    },
     presentationSourceStatus: function () {
-      var drawer = document.getElementById("presentationSourceDrawer");
+      var drawer = document.getElementById("sharedSourceDrawer");
       return drawer ? drawer.getAttribute("data-source-status") : null;
     },
     presentationSequenceRowIds: function () {

--- a/tests/test_viewer_e2e.py
+++ b/tests/test_viewer_e2e.py
@@ -178,9 +178,9 @@ def test_mobile_transport_stays_aligned_without_page_overflow(tmp_path):
             """() => {
               const buttons = [...document.querySelectorAll('.pres-transport button')]
                 .map((el) => { const r = el.getBoundingClientRect(); return [r.y, r.height]; });
-              const sourceTop = document.querySelector('#presentationSource')
-                .getBoundingClientRect().top;
               const scrubberTop = document.querySelector('#presentationScrubber')
+                .getBoundingClientRect().top;
+              const sourceTop = document.querySelector('#sharedSourceDrawer')
                 .getBoundingClientRect().top;
               return {
                 width: document.documentElement.scrollWidth,
@@ -191,7 +191,9 @@ def test_mobile_transport_stays_aligned_without_page_overflow(tmp_path):
         assert geometry["width"] == 360
         assert len({round(item[0], 2) for item in geometry["buttons"]}) == 1
         assert len({round(item[1], 2) for item in geometry["buttons"]}) == 1
-        assert geometry["sourceTop"] < geometry["scrubberTop"]
+        # #125 — mobile order: progress band ends the in-view layout; the
+        # shared source drawer follows below the whole shell
+        assert geometry["scrubberTop"] < geometry["sourceTop"]
         browser.close()
 
 
@@ -809,10 +811,10 @@ def test_simple_scrubber_viewports_no_overflow(tmp_path):
                 order = page.evaluate(
                     """() => {
                       const top = s => document.querySelector(s).getBoundingClientRect().top;
-                      return top('#presentationSource') < top('#presentationScrubber');
+                      return top('.pres-scrubber-wrap') < top('#sharedSourceDrawer');
                     }"""
                 )
-                assert order is True  # pinned mobile order: source before scrubber
+                assert order is True
             page.close()
         browser.close()
 
@@ -1032,7 +1034,7 @@ def test_sequence_header_geometry_and_stack_order(tmp_path):
               const col = document.querySelector('.pres-layout').getBoundingClientRect();
               const story = document.querySelector('.pres-story').getBoundingClientRect();
               const vp = document.querySelector('.pres-sequence-viewport').getBoundingClientRect();
-              const src = document.querySelector('#presentationSourceDrawer')
+              const src = document.querySelector('#sharedSourceDrawer')
                 .getBoundingClientRect();
               const scrub = document.querySelector('.pres-scrubber-wrap').getBoundingClientRect();
               return { actors, xs, ys, storyW: story.width, vpW: vp.width, vpTop: vp.top,
@@ -1043,7 +1045,9 @@ def test_sequence_header_geometry_and_stack_order(tmp_path):
         assert geo["xs"] == sorted(geo["xs"])  # left→right lane order
         assert max(geo["ys"]) - min(geo["ys"]) <= 1  # one header row
         assert geo["vpW"] >= geo["storyW"] - 2  # sequence spans the full column
-        assert geo["vpTop"] < geo["srcTop"] < geo["scrubTop"]  # pinned stack order
+        # #125 — in-view order: sequence then progress; the shared source
+        # drawer sits below the whole active shell (after evidence)
+        assert geo["vpTop"] < geo["scrubTop"] < geo["srcTop"]
         browser.close()
 
 
@@ -1238,8 +1242,8 @@ def test_source_drawer_default_open_and_state_safe_toggle(tmp_path):
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         page.goto(html.as_uri())
         assert page.evaluate("window.Funcviz.presentationSourceOpen()") is True
-        assert page.locator("#presentationSource").is_visible()
-        assert page.locator("#presentationSourceFileLabel").text_content() == "function_app.py"
+        assert page.locator("#sourcePanel").is_visible()
+        assert page.locator("#sharedSourceFileLabel").text_content() == "function_app.py"
         for _ in range(3):
             page.locator("#presentationNextBtn").click()
         page.wait_for_timeout(200)
@@ -1247,19 +1251,19 @@ def test_source_drawer_default_open_and_state_safe_toggle(tmp_path):
             "() => [window.Funcviz.getSelectedEventId(),"
             " document.querySelector('#presentationScrubber').dataset.progressPct]"
         )
-        page.locator("#presentationSourceDrawerSummary").click()  # collapse
+        page.locator("#sharedSourceDrawerSummary").click()  # collapse
         page.wait_for_timeout(100)
         assert page.evaluate("window.Funcviz.presentationSourceOpen()") is False
-        assert not page.locator("#presentationSource").is_visible()
+        assert not page.locator("#sourcePanel").is_visible()
         after = page.evaluate(
             "() => [window.Funcviz.getSelectedEventId(),"
             " document.querySelector('#presentationScrubber').dataset.progressPct]"
         )
         assert after == before  # toggling never touches replay/selection state
-        page.locator("#presentationSourceDrawerSummary").click()  # reopen
+        page.locator("#sharedSourceDrawerSummary").click()  # reopen
         assert page.evaluate("window.Funcviz.presentationSourceOpen()") is True
         # keyboard toggle works natively
-        page.focus("#presentationSourceDrawerSummary")
+        page.focus("#sharedSourceDrawerSummary")
         page.keyboard.press("Enter")
         assert page.evaluate("window.Funcviz.presentationSourceOpen()") is False
         browser.close()
@@ -1272,8 +1276,8 @@ def test_source_drawer_no_source_label_is_honest(tmp_path):
         browser = pw.chromium.launch()
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         page.goto(html.as_uri())
-        assert page.locator("#presentationSourceFileLabel").text_content() == "Source unavailable"
-        assert "Source text was not embedded" in page.locator("#presentationSource").text_content()
+        assert page.locator("#sharedSourceFileLabel").text_content() == "Source unavailable"
+        assert "Source text was not embedded" in page.locator("#sourcePanel").text_content()
         viewport_name = page.locator(".pres-sequence-viewport").get_attribute("aria-label")
         assert "horizontally scrollable" in viewport_name
         browser.close()
@@ -1309,7 +1313,7 @@ def test_sequence_viewport_responsive_no_page_overflow(tmp_path):
                 "#presentationResetBtn",
             ):
                 assert page.locator(btn).is_visible()
-            assert page.locator("#presentationSource").is_visible()
+            assert page.locator("#sourcePanel").is_visible()
             page.close()
         browser.close()
 
@@ -1545,8 +1549,8 @@ def test_shared_shell_content_geometry_unchanged(tmp_path):
         order = page.evaluate(
             """() => {
               const abs = e => document.querySelector(e).getBoundingClientRect().top;
-              return abs('.pres-sequence-viewport') < abs('#presentationSourceDrawer') &&
-                     abs('#presentationSourceDrawer') < abs('.pres-scrubber-wrap');
+              return abs('.pres-sequence-viewport') < abs('.pres-scrubber-wrap') &&
+                     abs('.pres-scrubber-wrap') < abs('#sharedEvidenceLayer');
             }"""
         )
         assert order is True
@@ -1716,19 +1720,19 @@ def test_probe_boundary_status_vs_content_availability(tmp_path):
         # worker-fail: lane not-reached AND source text absent — two dimensions
         page.goto(_viewer(tmp_path, "worker-fail").as_uri())
         assert page.evaluate("window.Funcviz.presentationSourceStatus()") == "not-reached"
-        assert page.locator("#presentationSourceFileLabel").text_content() == "Source unavailable"
-        assert "NOT REACHED" in page.locator("#presentationSourceStatus").text_content()
-        assert "No source file was recorded" in page.locator("#presentationSource").text_content()
+        assert page.locator("#sharedSourceFileLabel").text_content() == "Source unavailable"
+        assert "NOT REACHED" in page.locator("#sharedSourceStatus").text_content()
+        assert "No source file was recorded" in page.locator("#sourcePanel").text_content()
         # invocation-fail: app lane reached (code ran), host failed later
         page.goto(_viewer(tmp_path, "invocation-fail").as_uri())
         assert page.evaluate("window.Funcviz.presentationSourceStatus()") == "reached"
-        assert page.locator("#presentationSourceFileLabel").text_content() == "function_app.py"
+        assert page.locator("#sharedSourceFileLabel").text_content() == "function_app.py"
         # worker-unobserved: application lane unknown
         page.goto(_viewer(tmp_path, "worker-unobserved").as_uri())
         assert page.evaluate("window.Funcviz.presentationSourceStatus()") == "unknown"
-        assert "UNKNOWN" in page.locator("#presentationSourceStatus").text_content()
+        assert "UNKNOWN" in page.locator("#sharedSourceStatus").text_content()
         # drawer summary reads as the probe boundary
-        summary = page.locator("#presentationSourceDrawerSummary").text_content()
+        summary = page.locator("#sharedSourceDrawerSummary").text_content()
         assert "Source Probe" in summary and "your function code" in summary
         browser.close()
 
@@ -1778,7 +1782,7 @@ def test_probe_boundary_responsive_360(tmp_path):
         assert vp["canvas"] >= 660
         rail = page.evaluate(
             """() => getComputedStyle(
-                 document.querySelector('#presentationSourceDrawer'), '::before').left"""
+                 document.querySelector('#sharedSourceDrawer'), '::before').left"""
         )
         assert rail.endswith("px")  # JS-positioned rail stays inside the visible column
         browser.close()
@@ -1796,7 +1800,238 @@ def test_probe_boundary_mobile_event_and_source_remain_readable(tmp_path):
         event = page.locator("#presentationEvent")
         assert event.text_content() == "ApplicationFunctionStarted"
         assert event.evaluate("el => el.scrollHeight <= el.clientHeight + 1")
-        source = page.locator("#presentationSource .source-window")
+        source = page.locator("#sourcePanel .source-window")
         assert source.evaluate("el => el.scrollWidth > el.clientWidth")
         assert page.evaluate("document.documentElement.scrollWidth") == 360
+        browser.close()
+
+
+# --------------------------------------------------------------------------
+# #125 — shared Evidence + Source layers: step detail / error summary / call
+# stack / ONE source panel live BELOW both tabpanels, shared by both modes.
+# Only the central visualization differs; mode switches preserve node
+# identity, text, drawer state and replay; Presentation compacts low-level
+# evidence detail via CSS only.
+# --------------------------------------------------------------------------
+
+
+def test_shared_layers_ownership_singleton(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        own = page.evaluate(
+            """() => {
+              const q = id => document.getElementById(id);
+              return {
+                counts: ['stepDetail', 'errorSummary', 'stackPanel', 'sourcePanel']
+                  .map(id => document.querySelectorAll('#' + id).length),
+                evidenceUnder: q('stepDetail').closest('#sharedEvidenceLayer') !== null &&
+                  q('errorSummary').closest('#sharedEvidenceLayer') !== null &&
+                  q('stackPanel').closest('#sharedEvidenceLayer') !== null,
+                sourceUnder: q('sourcePanel').closest('#sharedSourceDrawer') !== null,
+                outsidePanels: ['stepDetail', 'errorSummary', 'stackPanel', 'sourcePanel']
+                  .every(id => !q(id).closest('#presentationView') &&
+                              !q(id).closest('#inspectView')),
+                afterShell: q('sharedEvidenceLayer').compareDocumentPosition(
+                  document.getElementById('activeViewShell')) &
+                  Node.DOCUMENT_POSITION_PRECEDING,
+                beforeFooter: document.querySelector('.app-footer')
+                  .compareDocumentPosition(q('sharedSourceDrawer')) &
+                  Node.DOCUMENT_POSITION_PRECEDING,
+                noPresentationSource: !document.getElementById('presentationSource'),
+              };
+            }"""
+        )
+        assert own["counts"] == [1, 1, 1, 1]
+        assert own["evidenceUnder"] is True
+        assert own["sourceUnder"] is True
+        assert own["outsidePanels"] is True
+        assert own["afterShell"]  # evidence comes after the active-view shell
+        assert own["beforeFooter"]  # source drawer precedes the footer
+        assert own["noPresentationSource"] is True  # duplicate removed
+        browser.close()
+
+
+def test_shared_layers_mode_switch_preserves_nodes_and_state(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "worker-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        for _ in range(3):
+            page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(150)
+        before = page.evaluate(
+            """() => ({
+              step: document.querySelector('#stepDetail .step-detail-name').textContent,
+              stackLanes: document.getElementById('stackPanel').getAttribute('data-stack-lanes'),
+              errorKind: document.getElementById('errorSummary')
+                .getAttribute('data-failure-kind'),
+              sourceText: document.querySelector('#sourcePanel .source-file')?.textContent ||
+                document.getElementById('sourcePanel').textContent.slice(0, 30),
+              open: window.Funcviz.sharedSourceOpen(),
+            })"""
+        )
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(300)
+        after = page.evaluate(
+            """() => ({
+              step: document.querySelector('#stepDetail .step-detail-name').textContent,
+              stackLanes: document.getElementById('stackPanel').getAttribute('data-stack-lanes'),
+              errorKind: document.getElementById('errorSummary')
+                .getAttribute('data-failure-kind'),
+              sourceText: document.querySelector('#sourcePanel .source-file')?.textContent ||
+                document.getElementById('sourcePanel').textContent.slice(0, 30),
+              open: window.Funcviz.sharedSourceOpen(),
+              title: document.getElementById('sharedSourceTitle').textContent,
+            })"""
+        )
+        assert after["step"] == before["step"]  # same nodes, same selection
+        assert after["stackLanes"] == before["stackLanes"]
+        assert after["errorKind"] == before["errorKind"]
+        assert after["sourceText"] == before["sourceText"]
+        assert after["open"] == before["open"]
+        assert after["title"] == "Application source"  # framing text follows mode
+        page.locator("#presentationTab").click()
+        page.wait_for_timeout(150)
+        assert (
+            page.locator("#sharedSourceTitle").text_content() == "Source Probe · your function code"
+        )
+        browser.close()
+
+
+def test_shared_layers_presentation_compact_evidence(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(150)
+
+        def evidence():
+            return page.evaluate(
+                """() => {
+                  const d = s => document.querySelector(s)
+                    ? getComputedStyle(document.querySelector(s)).display : 'absent';
+                  return { raw: d('#stepDetail .raw-log'),
+                           rawLabel: d('#stepDetail .raw-log-label'),
+                           detailId: d('#stepDetail .detail-id'),
+                           name: d('#stepDetail .step-detail-name'),
+                           meta: !!document.querySelector('#stepDetail .detail-grid'),
+                           errorTitle: d('#errorSummary .error-summary-title, ' +
+                                         '#errorSummary h2'),
+                           stackFrames: document.querySelectorAll('#stackPanel .stack-frame')
+                             .length };
+                }"""
+            )
+
+        pres = evidence()
+        assert pres["raw"] == "none"  # low-level detail recedes in Presentation
+        assert pres["rawLabel"] == "none"
+        assert pres["name"] != "none"  # semantic event stays
+        assert pres["meta"]  # elapsed/confidence rows stay
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(200)
+        insp = evidence()
+        assert insp["raw"] != "none"  # Inspect shows full forensic detail
+        assert insp["detailId"] != "none" if insp["detailId"] != "absent" else True
+        assert insp["name"] != "none"
+        browser.close()
+
+
+def test_shared_layers_source_framing_and_status(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        assert page.locator("#sharedSourceFileLabel").text_content() == "function_app.py"
+        assert page.evaluate("window.Funcviz.sharedSourceStatus()") == "reached"
+        # app row active: probe status flips while the worker owns execution
+        for _ in range(4):
+            page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(150)
+        assert page.evaluate("window.Funcviz.sharedSourceStatus()") == "active"
+        assert page.locator("#sourcePanel").get_attribute("data-app-active") == "true"
+        # drawer toggle persists across mode switch and replay
+        page.locator("#sharedSourceDrawerSummary").click()
+        assert page.evaluate("window.Funcviz.sharedSourceOpen()") is False
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.Funcviz.sharedSourceOpen()") is False  # persisted
+        page.locator("#replayNextBtn").click()
+        page.wait_for_timeout(100)
+        assert page.evaluate("window.Funcviz.sharedSourceOpen()") is False  # replay-safe
+        page.locator("#sharedSourceDrawerSummary").click()
+        assert page.evaluate("window.Funcviz.sharedSourceOpen()") is True
+        browser.close()
+
+
+def test_shared_layers_inspect_full_width_timeline(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1200})
+        page.goto(html.as_uri())
+        page.locator("#presentationNextBtn").click()
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(400)
+        geo = page.evaluate(
+            """() => {
+              const lay = document.querySelector('.layout').getBoundingClientRect();
+              const lanes = document.querySelector('#lanes').getBoundingClientRect();
+              const contentW = lay.width - 48; /* layout horizontal padding */
+              return {
+                laneNames: [...document.querySelectorAll('#lanes .lane')]
+                  .map(l => l.getAttribute('data-lane-name')),
+                lanesFull: Math.abs(lanes.width - contentW) <= 2,
+                ends: [...document.querySelectorAll('#lanes .axis-end')]
+                  .map(e => e.textContent.trim()),
+                connectors: window.Funcviz.connectorCount(),
+                railGone: !document.querySelector('.inspector-rail'),
+              };
+            }"""
+        )
+        assert geo["laneNames"] == ["client", "host", "python-worker", "application"]
+        assert geo["lanesFull"]  # timeline spans the full frame
+        assert geo["ends"] == ["end +294 ms"]
+        assert geo["connectors"] >= 1
+        assert geo["railGone"]
+        browser.close()
+
+
+def test_shared_layers_responsive_grid(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        for width, cols in ((1440, 3), (720, 1), (360, 1)):
+            page = browser.new_page(
+                viewport={"width": width, "height": 2000 if width != 1440 else 1400}
+            )
+            page.goto(html.as_uri())
+            got = page.evaluate(
+                """() => {
+                  const grid = document.querySelector('.shared-evidence-grid');
+                  const cols = getComputedStyle(grid).gridTemplateColumns.split(' ').length;
+                  const drawer = document.querySelector('#sharedSourceDrawer');
+                  const evGrid = document.querySelector('.shared-evidence-grid');
+                  return { cols,
+                           scrollW: document.documentElement.scrollWidth,
+                           gutter: Math.abs(drawer.getBoundingClientRect().left -
+                             evGrid.getBoundingClientRect().left) };
+                }"""
+            )
+            assert got["cols"] == cols, (width, got)
+            assert got["scrollW"] == width  # no page overflow at any width
+            assert got["gutter"] <= 1  # same gutter as the active shell
+            page.close()
         browser.close()


### PR DESCRIPTION
## Summary
- keep only the central visualization mode-specific: Presentation sequence vs full-width Inspect timeline
- move Step Detail, Error Summary, and Call Stack into one shared 3-column evidence layer
- consolidate source into one full-width shared drawer/node with mode-projected framing text
- preserve source model/window/provenance/status/open state and all replay/forensic semantics
- Presentation compacts low-level raw/ID detail; Inspect restores full forensic density
- remove the obsolete inspector rail and Presentation-only source duplicate

## Verification
- standard 162 passed / 59 skipped; Ruff, LSP, traces, Pages artifact
- Chromium viewer E2E 58 passed; Pages smoke 1
- singleton ownership for evidence/source IDs, mode-switch node/state preservation
- 1440 equal evidence columns; 720/360 stacked; no page overflow
- Inspect full-width 4-lane timeline/axis/connectors/source semantics intact
- Oracle 94/100, no blockers; title-span/comment nits fixed before PR

Closes #125