### PR TITLE
feat(viewer): strict shared-layer parity across both modes (#128)

### DIFF
--- a/src/funcviz/viewer/index.html
+++ b/src/funcviz/viewer/index.html
@@ -145,18 +145,11 @@
   /* #99 — text-safe semantic variants on dark; the dot keeps the Fluent fill hue */
   .outcome-chip[data-outcome="success"] { color: var(--ok-strong); border-color: rgba(16, 124, 16, .4); background: rgba(16, 124, 16, .08); }
   .outcome-chip[data-outcome="failed"] { color: var(--fail-strong); border-color: rgba(164, 38, 44, .4); background: rgba(164, 38, 44, .07); }
-  /* #84 — capture ended with no terminal evidence: never styled as clean success */
-  .outcome-chip[data-outcome="incomplete"] { color: var(--worker); border-color: rgba(161, 92, 0, .4); background: rgba(161, 92, 0, .06); }
-  /* #108 — Presentation header chip: persistent but subdued (small dot +
-     text, borderless) so the story's final verdict is the ONE strong read.
-     Inspect keeps the existing bordered chip exactly — these overrides are
-     scoped to presentation mode only; text/data stay accessible. */
-  body[data-view-mode="presentation"] .outcome-chip {
-    border-color: transparent;
-    background: transparent;
-  }
-  body[data-view-mode="presentation"] .outcome-chip .outcome-dot { margin: 0 6px 0 0; }
-  /* §2.1 — failure time in the summary line is subordinate, never the lead */
+   /* #84 — capture ended with no terminal evidence: never styled as clean success */
+   .outcome-chip[data-outcome="incomplete"] { color: var(--worker); border-color: rgba(161, 92, 0, .4); background: rgba(161, 92, 0, .06); }
+  /* #128 — the header outcome chip is IDENTICAL in both modes; the
+     Presentation story verdict remains central-canvas content only */
+   /* §2.1 — failure time in the summary line is subordinate, never the lead */
   .fail-at { color: var(--text-faint); font-weight: 400; font-size: 13px; }
   .runtime-meta {
     margin: 0 0 0 auto; font-family: var(--mono); font-size: 12px;
@@ -331,64 +324,16 @@
     margin: var(--sp-3) 0 var(--sp-1);
     font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--text);
   }
-  .confidence-detail { margin: 0 0 var(--sp-2); font-size: 13px; line-height: 1.6; color: var(--text-dim); }
+   .confidence-detail { margin: 0 0 var(--sp-2); font-size: 13px; line-height: 1.6; color: var(--text-dim); }
+  /* #128 — the #106 compact Presentation legend is REMOVED: the full #61
+     banner (title, counts, Details toggle, disclosure body) is the ONE
+     projection in both modes; no mode-conditioned confidence CSS remains. */
 
-  /* ============================================================
-     #106 — compact Presentation confidence legend. ONE banner, two
-     projections of the same renderConfidenceBanner data: Presentation
-     shows a one-line signal-grammar strip (no title, no counts, no
-     Details toggle/body); Inspect keeps the full banner exactly as
-     before. body[data-view-mode] CSS only — display:none removes the
-     hidden projection from layout AND the a11y/focus tree; the
-     collapsed state + toggle survive every mode switch untouched.
-     Default (pre-boot, no data-view-mode) = presentation, the boot mode.
-     ============================================================ */
-  .confidence-legend {
-    display: flex; flex-wrap: wrap; align-items: center;
-    gap: var(--sp-1) var(--sp-4);
-    margin: 0; padding: 0; list-style: none;
-    font-family: var(--mono); font-size: 11px; color: var(--text-dim);
-    min-height: 22px;
-  }
-  .confidence-legend-item {
-    display: inline-flex; align-items: center; gap: 7px; white-space: nowrap;
-  }
-  /* samples mirror the schematic conductor grammar exactly — style is the
-     cue, color only confirms (never the sole signal) */
-  .confidence-legend-sample {
-    flex: none; width: 18px; height: 0;
-    border-top: 2px solid var(--schem-line);
-  }
-  .confidence-legend-sample--inferred { border-top-style: dashed; }
-  .confidence-legend-sample--not-reached { border-top-style: dotted; }
-  .confidence-legend-sample--unknown { /* hatched hollow square — unknown terminal grammar */
-    width: 10px; height: 10px;
-    border: 1px solid var(--text-dim);
-    background-image: repeating-linear-gradient(-45deg,
-      rgba(50, 49, 48, .35) 0 3px, rgba(50, 49, 48, 0) 3px 6px);
-  }
-  .confidence-legend-empty { color: var(--text-faint); }
-  /* Presentation strip: full banner chrome hidden; banner padding clamps the
-     band to the 28–34px target (5px + 22px legend + 5px + 2px borders) */
-  #confidenceBanner .confidence-head,
-  #confidenceBanner .confidence-body { display: none; }
-  #confidenceBanner { padding: 5px var(--sp-4); }
-  /* Inspect: the exact #61 banner — head row, counts, Details toggle, body */
-  body[data-view-mode="inspect"] #confidenceBanner { padding: var(--sp-2) var(--sp-4); }
-  body[data-view-mode="inspect"] #confidenceBanner .confidence-head { display: flex; }
-  body[data-view-mode="inspect"] #confidenceBanner .confidence-body { display: grid; }
-  body[data-view-mode="inspect"] #confidenceBanner .confidence-legend { display: none; }
-  @media (forced-colors: active) {
-    /* #106 — samples stay grammar-distinct with system colors */
-    #confidenceBanner .confidence-legend-sample { border-top-color: CanvasText; }
-    #confidenceBanner .confidence-legend-sample--unknown { border-color: CanvasText; }
-  }
-
-  /* ============================================================
-     replay transport (#7) — Inspect bar, now projected inside the #120
-     shared shell (was sticky inside the timeline column; the shared
-     fixed layer replaces that stickiness at one stable position)
-     ============================================================ */
+   /* ============================================================
+      replay transport (#7) — Inspect bar, now projected inside the #120
+      shared shell (was sticky inside the timeline column; the shared
+      fixed layer replaces that stickiness at one stable position)
+      ============================================================ */
   .replay-controls {
     position: static;
     display: flex; flex-wrap: wrap; align-items: center; gap: var(--sp-2);
@@ -452,12 +397,8 @@
   @media (max-width: 900px) {
     .shared-evidence-grid { grid-template-columns: minmax(0, 1fr); }
   }
-  /* Presentation compacts evidence via CSS ONLY: correlation ID rows and the
-     raw-log block recede; semantic event/elapsed/confidence, error message/
-     component and stack frames always stay */
-  body[data-view-mode="presentation"] #sharedEvidenceLayer .detail-id,
-  body[data-view-mode="presentation"] #sharedEvidenceLayer .raw-log-label,
-  body[data-view-mode="presentation"] #sharedEvidenceLayer .raw-log { display: none; }
+  /* #128 — evidence density is IDENTICAL in both modes (raw log and
+     correlation IDs always render; no mode-conditioned selectors) */
   /* the shared source drawer is bottom full-width in both modes; no sticky;
      the max() margin trick keeps the shell gutter at narrow widths and
      centers under the 1440 cap at wide ones */
@@ -466,8 +407,6 @@
     margin: var(--sp-3) max(var(--sp-5), calc((100% - 1440px) / 2)) 0;
   }
   #sharedSourceDrawer .source-panel { position: static; }
-  /* probe rail terminates at the shared drawer top (Presentation only) */
-  body[data-view-mode="inspect"] #sharedSourceDrawer::before { display: none; }
 
   /* ============================================================
      durations — three separately-labeled chips (R4: never collapse)
@@ -1228,11 +1167,15 @@
   .view-switch-note { margin: 0; font-size: 11.5px; font-style: italic; color: var(--text-faint); }
 
   .active-view-shell { width: 100%; }
-  #presentationView { display: flow-root; }
-  .view-confidence-slot { width: 100%; grid-column: 1 / -1; }
-  .view-confidence-slot:empty { display: none; }
-  /* hidden must win over any author display on the two panels */
-  #presentationView[hidden], #inspectView[hidden] { display: none !important; }
+   #presentationView { display: flow-root; }
+   .view-confidence-slot { width: 100%; grid-column: 1 / -1; }
+   .view-confidence-slot:empty { display: none; }
+  /* #128 — strict parity: the Presentation slot is a direct (unpadded) child
+     of its view; the Inspect slot lives inside padded .layout, so negative
+     margins pull it out to the SAME full width in both modes */
+  #inspectConfidenceSlot { margin: 0 calc(-1 * var(--sp-5)); width: auto; }
+   /* hidden must win over any author display on the two panels */
+   #presentationView[hidden], #inspectView[hidden] { display: none !important; }
 
   /* #99/#117 — Runtime Schematic chassis, now ONE full-width stack:
      story → sequence viewport → source drawer → progress → transport.
@@ -1349,9 +1292,8 @@
   /* ---- runtime flow — full-width sequence canvas (#97, #99, #117) ------- */
   /* #117 — the flow is a horizontal sequence diagram: a scrollable viewport
      (keyboard focusable, page never overflows) wrapping the #presentationFlow
-     canvas — a fixed 4-column actor grid (client | host | worker | app), one
-     header row of actor cells, then one row per replayable event. Lifelines
-     are neutral structure; lane truth stays on the actor cells. */
+     canvas — three runtime actor columns plus the connected source boundary,
+     followed by one row per replayable event. */
   .pres-sequence-viewport {
     background: var(--schem-chassis);
     border: 1px solid var(--border-strong);
@@ -1785,20 +1727,11 @@
     border: 1px solid var(--border-strong);
     border-radius: var(--schem-radius);
     box-shadow: none;
-    position: relative; /* #122 — probe rail anchors to the drawer top */
   }
-  /* #122 — decorative probe rail: dashed vertical cue continuing from the
-     worker-edge port down to the drawer; positioning set by JS from the
-     actual worker column edge (--probe-rail-left). No timing meaning. */
-  .pres-source-drawer::before {
-    content: ""; position: absolute; top: calc(-1 * var(--sp-3)); bottom: auto;
-    left: var(--probe-rail-left, 90%); width: 0; height: var(--sp-3);
-    border-left: 2px dashed var(--schem-line);
-    pointer-events: none;
-  }
-  .pres-source-drawer[data-source-status="active"]::before { border-left-color: var(--azure-blue); }
-  .pres-source-drawer[data-source-status="unknown"]::before { border-left-style: dotted; }
-  .pres-source-drawer[data-source-status="not-reached"]::before { border-left-style: dotted; border-left-color: var(--border-strong); }
+  /* #128 — the #122 decorative probe rail is REMOVED: the shared source
+     layer must look identical in both modes; the Source Probe connection
+     stays semantic in the central Presentation canvas (worker→probe rows
+     and story copy) only */
   /* #122 — probe status chip on the summary: visible accessible status */
   .pres-source-drawer-sub { font-weight: 400; letter-spacing: 0; text-transform: none; color: var(--text-faint); }
   .pres-source-drawer-status {
@@ -1849,19 +1782,15 @@
    .pres-source-drawer[open] summary { border-radius: var(--schem-radius) var(--schem-radius) 0 0; }
   /* #125 — the ONE shared source panel inside the drawer: static, seamless;
      the #99/#104 app-active probe grammar applies in Presentation framing */
-  #sharedSourceDrawer .source-panel {
-    position: static; margin: 0;
-    border: none; border-top: 1px solid var(--border);
-    border-radius: 0;
-    transition: border-color .2s ease, box-shadow .2s ease;
-  }
-  body[data-view-mode="presentation"] #sourcePanel[data-app-active="true"] {
-    border-color: rgba(0, 120, 212, .6);
-    box-shadow: inset 3px 0 0 var(--azure-blue); /* probe rail jack */
-  }
-  body[data-view-mode="presentation"] #sourcePanel[data-app-active="true"] .source-head {
-    background: rgba(0, 120, 212, .08);
-  }
+   #sharedSourceDrawer .source-panel {
+     position: static; margin: 0;
+     border: none; border-top: 1px solid var(--border);
+     border-radius: 0;
+   }
+  /* #128 — no mode-conditioned source styling: the shared panel looks the
+     same in both modes (data-app-active remains a state hook only; the
+     Source Probe accent lives in the central Presentation canvas) */
+
 
   /* ---- presentation transport — flat command strip (#97, #99) ---------- */
   .pres-transport {
@@ -1872,13 +1801,15 @@
     border-radius: var(--radius-sm);
     box-shadow: none;
   }
-  /* #99 — latching LED on the primary control: lit only while playing
-     (aria-pressed), a discrete non-glow pressed indication */
-  .pres-transport .btn--primary::before {
+  /* #99/#128 — latching LED on the shared primary transport control: lit
+     only while playing (aria-pressed), a discrete non-glow pressed
+     indication. Scoped to the shell so BOTH mode groups render it
+     identically (toolbar primary buttons are unaffected) */
+  #sharedTransportLayer .btn--primary::before {
     content: ""; width: 6px; height: 6px; border-radius: 1px;
     background: rgba(255, 255, 255, .55); margin-right: 6px;
   }
-  .pres-transport .btn--primary[aria-pressed="true"]::before { background: #FFFFFF; }
+  #sharedTransportLayer .btn--primary[aria-pressed="true"]::before { background: #FFFFFF; }
 
   /* #97/#99 — reduced motion: handoffs go discrete (weight + marker, no
      travel, no glow); pulses and transitions are dropped, semantic state
@@ -1926,7 +1857,6 @@
     .sequence-probe-jack { border-color: CanvasText; }
     .sequence-probe-arrow { border-left-color: CanvasText; }
     .sequence-probe-marker { border-color: CanvasText; }
-    .pres-source-drawer::before { border-left-color: CanvasText; }
     .sequence-message-line { border-top-color: CanvasText; }
     .sequence-message-arrow--right { border-left-color: CanvasText; }
     .sequence-message-arrow--left { border-right-color: CanvasText; }
@@ -1967,11 +1897,9 @@
     .trace-loader .toolbar { padding: var(--sp-2) var(--sp-4) var(--sp-3); }
     .view-switch { padding: 0 var(--sp-4); }
     .view-switch-note { flex-basis: 100%; }
-    /* #97 — the shared banner must fit the mobile Presentation viewport:
-       title/toggle stay together and counts get their own row.
-       #106 — the head only exists in Inspect now; scope the grid to it so
-       the id-scoped flex restore above cannot out-specify the mobile layout */
-    body[data-view-mode="inspect"] #confidenceBanner .confidence-head {
+    /* #97 — the shared banner must fit the mobile viewport: title/toggle
+       stay together and counts get their own row (#128: unconditional) */
+    #confidenceBanner .confidence-head {
       display: grid; grid-template-columns: minmax(0, 1fr) auto;
     }
     .confidence-banner-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
@@ -2055,6 +1983,10 @@
     <button type="button" class="btn btn--primary" id="presentationPlayBtn" aria-pressed="false" disabled>Play</button>
     <button type="button" class="btn" id="presentationNextBtn" disabled>Next</button>
     <button type="button" class="btn" id="presentationResetBtn" disabled>Reset</button>
+    <!-- #128 — strict parity: the visible projection mirrors the Inspect bar
+         exactly, including the live playhead clock and replay status -->
+    <span class="replay-clock" id="presentationClock" hidden></span>
+    <span class="replay-status" id="presentationStatus" role="status" aria-live="polite">No events</span>
   </div>
   <div class="replay-controls" role="group" aria-label="Replay transport controls">
     <span class="replay-title">Replay</span>
@@ -2077,10 +2009,9 @@
      renderPresentationStatic() + updatePresentationView(). -->
 <section id="presentationView" role="tabpanel" aria-labelledby="presentationTab" tabindex="0">
   <div id="presentationConfidenceSlot" class="view-confidence-slot">
-    <!-- issue #10 / #106 — one confidence truth, projected at the top of
-         the active view: compact signal legend in Presentation, full
-         expandable boundary in Inspect. The node itself moves between
-         slots on mode switches; it is never cloned. -->
+    <!-- issue #10 — one confidence truth: the FULL banner is identical in
+         both modes (#128); the node moves between the active-view slots on
+         mode switches and is never cloned. -->
     <section id="confidenceBanner" class="confidence-banner" aria-labelledby="confidenceBannerTitle"></section>
   </div>
   <div class="pres-layout">
@@ -2101,9 +2032,8 @@
     </section>
 
     <!-- #117 — full-width sequence canvas: the flow is a horizontally
-         scrollable viewport (keyboard focusable) whose inner canvas holds a
-         4-column actor grid; #presentationFlow keeps its ID and remains the
-         element JS renders into -->
+         scrollable viewport whose inner canvas holds three runtime actors
+         and the connected source boundary -->
     <div class="pres-sequence-viewport" tabindex="0" role="group" aria-label="Runtime sequence diagram — client, functions host, python worker; application source probe below; horizontally scrollable on narrow screens">
       <section class="pres-flow" id="presentationFlow" aria-label="Runtime flow — client, functions host, python worker; application source probe below"></section>
     </div>
@@ -2156,9 +2086,8 @@
 </div>
 
 <!-- #125 — SHARED Evidence layer: Step Detail | Error Summary | Call Stack,
-     one always-mounted DOM below the active view. The same nodes serve both
-     modes (IDs unchanged); Presentation compacts low-level detail via CSS
-     only, Inspect shows full forensic detail. -->
+      one always-mounted DOM below the active view. The same nodes serve both
+      modes with identical content, density, and accessibility. -->
 <section id="sharedEvidenceLayer" aria-label="Selected event evidence">
   <div class="shared-evidence-grid">
     <section id="stepDetail" class="step-detail" aria-labelledby="stepDetailTitle" aria-live="polite"></section>
@@ -2178,14 +2107,12 @@
 </section>
 
 <!-- #125 — SHARED Source layer: ONE visible source DOM node (#sourcePanel)
-     rendered by the single renderSource()/buildSourceModel() truth. Framing
-     text changes by mode (Presentation: Source Probe · your function code;
-     Inspect: Application source); content, file label, runtime status and
-     provenance are identical. Open state persists across mode switches and
-     replay; default open. -->
+      rendered by the single renderSource()/buildSourceModel() truth. Content,
+      title, file label, runtime status, provenance, and open state remain
+      identical across mode switches and replay. -->
 <details id="sharedSourceDrawer" class="pres-source-drawer shared-source-drawer" open>
   <summary id="sharedSourceDrawerSummary">
-    <span class="pres-source-drawer-title" id="sharedSourceTitle"><span id="sharedSourceTitleMain">Source Probe</span><span class="pres-source-drawer-sub" id="sharedSourceTitleSub"> · your function code</span></span>
+    <span class="pres-source-drawer-title" id="sharedSourceTitle">Application source</span>
     <span class="pres-source-drawer-status" id="sharedSourceStatus">NOT REACHED</span>
     <span class="pres-source-drawer-file" id="sharedSourceFileLabel"></span>
     <span class="pres-source-drawer-hint pres-source-drawer-hint--collapse">Collapse</span>
@@ -2628,7 +2555,6 @@
     var body;
     var inner;
     var summary;
-    var legend;
 
     for (i = 0; trace && i < CONFIDENCE_LANE_ORDER.length; i++) {
       key = CONFIDENCE_LANE_ORDER[i];
@@ -2700,38 +2626,6 @@
     inner = el("div", "confidence-body-inner");
     body.appendChild(inner);
     banner.appendChild(body);
-
-    /* #106 — compact Presentation legend: the SAME schema truth (observed /
-       inferred / unknown / notReached above) rendered as a one-line signal-
-       grammar key matching the schematic conductors exactly — solid observed,
-       dashed inferred, hatched unknown, dotted not-reached. Conditional items
-       only when the trace actually has them; no trace = honest empty label.
-       Which projection (legend vs full banner) is visible is decided purely by
-       body[data-view-mode] CSS — no state, no rerender, and the Inspect
-       collapsed/toggle state is never touched by switching modes. */
-    legend = el("ul", "confidence-legend");
-    legend.setAttribute("aria-label", "Signal legend");
-    function legendItem(sampleClass, label) {
-      var item = el("li", "confidence-legend-item");
-      var sample = el("span", "confidence-legend-sample " + sampleClass);
-      sample.setAttribute("aria-hidden", "true");
-      item.appendChild(sample);
-      item.appendChild(tx(label));
-      return item;
-    }
-    if (!trace) {
-      legend.appendChild(el("li", "confidence-legend-empty", "No trace loaded"));
-    } else {
-      legend.appendChild(legendItem("confidence-legend-sample--observed", "observed"));
-      legend.appendChild(legendItem("confidence-legend-sample--inferred", "inferred"));
-      if (unknown.length) {
-        legend.appendChild(legendItem("confidence-legend-sample--unknown", "unknown"));
-      }
-      if (notReached.length) {
-        legend.appendChild(legendItem("confidence-legend-sample--not-reached", "not reached"));
-      }
-    }
-    banner.appendChild(legend);
 
     if (!trace) {
       detail = CONFIDENCE_DETAIL_NO_TRACE;
@@ -3415,14 +3309,20 @@
   }
 
   function updateClockHidden() {
+    var hidden = Boolean(prePlay) || !timeScaleCache || sweepNodes.length === 0;
     var clock = document.getElementById("playheadClock");
-    if (clock) clock.hidden = Boolean(prePlay) || !timeScaleCache || sweepNodes.length === 0;
+    var mirrorClock = document.getElementById("presentationClock");
+    if (clock) clock.hidden = hidden;
+    if (mirrorClock) mirrorClock.hidden = hidden; /* #128 — parity projection */
   }
 
   function updatePlayheadClock() {
     var clock = document.getElementById("playheadClock");
     if (!clock || !timeScaleCache || playheadMsValue == null) return;
-    clock.textContent = "t +" + Math.round(playheadMsValue) + " ms";
+    var text = "t +" + Math.round(playheadMsValue) + " ms";
+    clock.textContent = text;
+    var mirrorClock = document.getElementById("presentationClock");
+    if (mirrorClock) mirrorClock.textContent = text; /* #128 — parity projection */
   }
 
   function stopSweepFrames() {
@@ -4481,29 +4381,6 @@
      the sequence viewport and the source drawer, aligned under the WORKER
      column's right edge (where the probe port is). Presentation-only; no
      timing meaning; repositioned on resize via the existing listener. */
-  /* #122/#125 — decorative probe rail: a dashed vertical cue at the SHARED
-     source drawer's top, aligned under the WORKER column's right edge (where
-     the sequence probe port is). Presentation-only (hidden by mode CSS in
-     Inspect); no timing meaning; repositioned on resize. */
-  function updateSourceProbeRail() {
-    var drawer = document.getElementById("sharedSourceDrawer");
-    var viewport = document.querySelector(".pres-sequence-viewport");
-    if (!drawer || !viewport || typeof drawer.style.setProperty !== "function") return;
-    var vRect = viewport.getBoundingClientRect();
-    var dRect = drawer.getBoundingClientRect();
-    var worker = document.querySelector(
-      '#presentationFlow .pres-actor[data-presentation-lane="python-worker"]');
-    var x = null;
-    var wRect = null;
-    if (worker) {
-      wRect = worker.getBoundingClientRect();
-      x = (wRect.right - dRect.left) - 24; /* under the worker edge port */
-    }
-    if (x == null || !isFinite(x)) x = dRect.width * 0.9;
-    x = Math.max(16, Math.min(x, dRect.width - 16)); /* stay visible when scrolled */
-    drawer.style.setProperty("--probe-rail-left", x + "px");
-  }
-
   /* ---------------- #97 — Presentation projection ----------------------- */
   /* Everything below derives from the SAME state the Inspect timeline
      renders: currentTrace.lanes (actor statuses), the timed event chain
@@ -4532,7 +4409,6 @@
     var banner = document.getElementById("confidenceBanner");
     var confidenceSlot = document.getElementById(presActive
       ? "presentationConfidenceSlot" : "inspectConfidenceSlot");
-    var sharedTitle = null;
     if (banner && confidenceSlot && banner.parentElement !== confidenceSlot) {
       confidenceSlot.appendChild(banner);
     }
@@ -4543,20 +4419,8 @@
     inspTab.setAttribute("aria-selected", presActive ? "false" : "true");
     presTab.tabIndex = presActive ? 0 : -1;
     inspTab.tabIndex = presActive ? -1 : 0;
-    /* #108 — Presentation announces the story verdict only. Its header chip
-       remains a subdued visual status; Inspect restores the trace-level
-       status to the accessibility tree. */
-    document.getElementById("outcomeChip").setAttribute("aria-hidden",
-      presActive ? "true" : "false");
-    /* #125 — shared source framing text follows the mode (text only; never
-       a rerender, never a state reset; content/status stay identical) */
-    sharedTitle = document.getElementById("sharedSourceTitleMain");
-    if (sharedTitle) sharedTitle.textContent = presActive ? "Source Probe" : "Application source";
-    sharedTitle = document.getElementById("sharedSourceTitleSub");
-    if (sharedTitle) {
-      sharedTitle.textContent = presActive ? " \u00b7 your function code" : "";
-      sharedTitle.hidden = !presActive;
-    }
+    /* #128 — strict parity: the header outcome chip and the shared source
+       title are identical in both modes; applyViewMode never mutates them */
     if (!presActive && !prePlay) {
       window.requestAnimationFrame(relayoutInspectGeometry);
     }
@@ -4906,7 +4770,6 @@
     }
     flow.appendChild(rowsBox);
     applyPresentationSourceStatus(trace, null); /* #122/#125 — shared probe status from lane truth */
-    updateSourceProbeRail(); /* #122/#125 — decorative rail tracks the worker column edge */
     startLabel = document.getElementById("presentationScrubberStart");
     endLabel = document.getElementById("presentationScrubberEnd");
     startLabel.textContent = scale.t0 + " ms";
@@ -5368,6 +5231,20 @@
         dst.textContent = src.textContent;
         dst.setAttribute("aria-pressed", src.getAttribute("aria-pressed"));
       }
+    }
+    /* #128 — strict parity: clock visibility/text and status state/text are
+       mirrored into the Presentation projection from the same truth */
+    src = document.getElementById("playheadClock");
+    dst = document.getElementById("presentationClock");
+    if (src && dst) {
+      dst.hidden = src.hidden;
+      dst.textContent = src.textContent;
+    }
+    src = document.getElementById("replayStatus");
+    dst = document.getElementById("presentationStatus");
+    if (src && dst) {
+      dst.setAttribute("data-state", src.getAttribute("data-state"));
+      dst.textContent = src.textContent;
     }
   }
 
@@ -5855,7 +5732,6 @@
      if (staggerResizeTimer != null) window.clearTimeout(staggerResizeTimer);
      staggerResizeTimer = window.setTimeout(function () {
        relayoutInspectGeometry();
-       updateSourceProbeRail(); /* #122 — decorative probe rail tracks the worker edge */
      }, 120);
    });
 

--- a/tests/test_viewer_e2e.py
+++ b/tests/test_viewer_e2e.py
@@ -555,131 +555,73 @@ def test_trace_loader_360_no_overflow(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# #106 — compact Presentation confidence legend. ONE #confidenceBanner, two
-# CSS projections: Presentation = one-line signal-grammar strip (no title,
-# counts, toggle or body), Inspect = the unchanged full banner with counts,
-# Details toggle and expansion state preserved across mode switches.
+# #128 — strict shared-layer parity. The #106 compact legend is REMOVED: the
+# full confidence banner (title, counts, Details toggle, body) is the ONE
+# projection, identical in both modes; expansion state survives switches.
 # --------------------------------------------------------------------------
 
 
-def test_confidence_legend_compact_in_presentation(tmp_path):
-    playwright = pytest.importorskip("playwright.sync_api")
-    html = _viewer(tmp_path, "success")
-    with playwright.sync_playwright() as pw:
-        browser = pw.chromium.launch()
-        page = browser.new_page(viewport={"width": 1440, "height": 1000})
-        page.goto(html.as_uri())
-        assert page.locator(".confidence-legend").is_visible()
-        # full banner chrome leaves layout AND the focus/a11y tree
-        assert not page.locator(".confidence-head").is_visible()
-        assert not page.locator(".confidence-body").is_visible()
-        assert not page.locator(".confidence-toggle").is_visible()
-        assert page.locator(".confidence-toggle").get_attribute("aria-expanded") == "false"
-        height = page.evaluate(
-            "() => document.querySelector('#confidenceBanner').getBoundingClientRect().height"
-        )
-        assert height <= 38  # 28–34px strip (+ rounding tolerance)
-        samples = page.evaluate(
-            """() => {
-              const cs = s => getComputedStyle(document.querySelector(s));
-              return {
-                observed: cs('.confidence-legend-sample--observed').borderTopStyle,
-                inferred: cs('.confidence-legend-sample--inferred').borderTopStyle,
-              };
-            }"""
-        )
-        assert samples["observed"] == "solid"  # schematic conductor grammar
-        assert samples["inferred"] == "dashed"
-        # legend is labelled for AT
-        assert page.locator(".confidence-legend").get_attribute("aria-label") == "Signal legend"
-        browser.close()
-
-
-def test_confidence_legend_conditional_items(tmp_path):
-    playwright = pytest.importorskip("playwright.sync_api")
-    with playwright.sync_playwright() as pw:
-        browser = pw.chromium.launch()
-
-        def items(page):
-            return page.locator(".confidence-legend-item").all_inner_texts()
-
-        page = browser.new_page(viewport={"width": 1440, "height": 1000})
-        page.goto(_viewer(tmp_path, "success").as_uri())
-        assert items(page) == ["observed", "inferred"]  # no unknown / not-reached lanes
-        page.goto(_viewer(tmp_path, "worker-unobserved").as_uri())
-        assert items(page) == ["observed", "inferred", "unknown"]  # 2 unknown lanes exist
-        unknown_sample = page.evaluate(
-            """() => {
-              const s = document.querySelector('.confidence-legend-sample--unknown');
-              return s && getComputedStyle(s).backgroundImage.includes('repeating-linear-gradient');
-            }"""
-        )
-        assert unknown_sample  # hatched/hollow sample grammar
-        page.goto(_viewer(tmp_path, "worker-fail").as_uri())
-        assert items(page) == ["observed", "inferred", "not reached"]  # downstream lanes stopped
-        dotted = page.evaluate(
-            """() => getComputedStyle(
-                 document.querySelector('.confidence-legend-sample--not-reached')
-               ).borderTopStyle"""
-        )
-        assert dotted == "dotted"
-        # no trace: the legend says so instead of implying grammar items
-        page.evaluate("window.Funcviz.clear()")
-        assert page.locator(".confidence-legend").text_content() == "No trace loaded"
-        browser.close()
-
-
-def test_confidence_legend_mode_switch_and_state(tmp_path):
+def test_confidence_banner_identical_across_modes(tmp_path):
     playwright = pytest.importorskip("playwright.sync_api")
     html = _viewer(tmp_path, "worker-fail")
     with playwright.sync_playwright() as pw:
         browser = pw.chromium.launch()
         page = browser.new_page(viewport={"width": 1440, "height": 1000})
         page.goto(html.as_uri())
-        attrs_before = page.evaluate(
-            "() => ({...document.querySelector('#confidenceBanner').dataset})"
-        )
-        page.locator("#inspectTab").click()
-        # Inspect: compact hidden, full banner exactly available
-        assert not page.locator(".confidence-legend").is_visible()
-        assert page.locator(".confidence-head").is_visible()
-        assert page.locator(".confidence-toggle").is_visible()
-        assert "not reached" in page.locator(".confidence-oneline").text_content()
-        assert not page.locator(".confidence-body-inner").is_visible()  # collapsed at rest
+
+        def banner():
+            return page.evaluate(
+                """() => {
+                  const b = document.querySelector('#confidenceBanner');
+                  const cs = getComputedStyle(b);
+                  return {
+                    legendGone: !document.querySelector('.confidence-legend'),
+                    title: document.querySelector('.confidence-banner-title').textContent,
+                    headVisible: document.querySelector('.confidence-head')
+                      .offsetParent !== null,
+                    toggleVisible: document.querySelector('.confidence-toggle')
+                      .offsetParent !== null,
+                    counts: document.querySelector('.confidence-oneline').textContent,
+                    height: Math.round(b.getBoundingClientRect().height),
+                    padding: cs.padding,
+                    bodyVisible: getComputedStyle(
+                      document.querySelector('.confidence-body-inner')).visibility === 'visible',
+                  };
+                }"""
+            )
+
+        pres = banner()
+        assert pres["legendGone"] is True  # #106 legend fully removed
+        assert pres["title"] == "Trace confidence boundary"
+        assert pres["headVisible"] and pres["toggleVisible"]
+        assert "not reached" in pres["counts"]
+        assert not pres["bodyVisible"]  # collapsed at rest
         page.locator(".confidence-toggle").click()  # Details expands
         page.wait_for_timeout(300)
         assert page.locator(".confidence-body-inner").is_visible()
-        page.locator("#presentationTab").click()
-        # Presentation again: full content hidden, legend back
-        assert page.locator(".confidence-legend").is_visible()
-        assert not page.locator(".confidence-head").is_visible()
-        assert not page.locator(".confidence-body-inner").is_visible()
+        pres = banner()  # parity snapshot at the SAME expanded state
         page.locator("#inspectTab").click()
-        # expansion state survived the round trip
+        page.wait_for_timeout(200)
+        insp = banner()
+        for key in pres:
+            assert insp[key] == pres[key], key  # identical projection + state
         assert page.locator("#confidenceBanner").get_attribute("data-collapsed") == "false"
         assert page.locator(".confidence-toggle").get_attribute("aria-expanded") == "true"
-        assert page.locator(".confidence-body-inner").is_visible()
-        attrs_after = page.evaluate(
-            "() => ({...document.querySelector('#confidenceBanner').dataset})"
-        )
-        attrs_after["collapsed"] = attrs_before["collapsed"]  # only the intended toggle delta
-        assert attrs_after == attrs_before
+        page.locator("#presentationTab").click()
+        page.wait_for_timeout(150)
+        assert banner()["bodyVisible"] is True  # expansion survives the round trip
         browser.close()
 
 
-def test_confidence_legend_360_no_overflow(tmp_path):
+def test_confidence_banner_360_no_overflow(tmp_path):
     playwright = pytest.importorskip("playwright.sync_api")
     html = _viewer(tmp_path, "worker-unobserved")
     with playwright.sync_playwright() as pw:
         browser = pw.chromium.launch()
         page = browser.new_page(viewport={"width": 360, "height": 1600})
         page.goto(html.as_uri())
-        assert page.locator(".confidence-legend").is_visible()
+        assert page.locator(".confidence-head").is_visible()
         assert page.evaluate("document.documentElement.scrollWidth") == 360
-        legend_w = page.evaluate(
-            "() => document.querySelector('.confidence-legend').getBoundingClientRect().width"
-        )
-        assert legend_w <= 360
         page.locator("#inspectTab").click()
         assert page.evaluate("document.documentElement.scrollWidth") == 360
         browser.close()
@@ -848,11 +790,11 @@ def test_outcome_dedupe_body_attrs_and_header_chip_projection(tmp_path):
                      document.body.getAttribute('data-presentation-outcome')]"""
         )
         assert attrs == ["pre-play", "none"]  # mirrored projection on <body>
-        subdued = chip()  # Presentation: borderless/transparent, same shell geometry
-        assert subdued["border"] == "rgba(0, 0, 0, 0)"
-        assert subdued["bg"] == "rgba(0, 0, 0, 0)"
-        assert subdued["pad"] == "4px 12px 4px 8px"
-        assert page.locator("#outcomeChip").get_attribute("aria-hidden") == "true"
+        pres = chip()  # #128 — the chip is IDENTICAL in both modes
+        assert pres["border"] != "rgba(0, 0, 0, 0)"
+        assert pres["bg"] != "rgba(0, 0, 0, 0)"
+        assert pres["pad"] == "4px 12px 4px 8px"
+        assert page.locator("#outcomeChip").get_attribute("aria-hidden") is None
         page.locator("#presentationNextBtn").click()
         page.wait_for_timeout(100)
         attrs = page.evaluate(
@@ -862,11 +804,9 @@ def test_outcome_dedupe_body_attrs_and_header_chip_projection(tmp_path):
         assert attrs == ["running", "none"]
         page.locator("#inspectTab").click()
         page.wait_for_timeout(100)
-        restored = chip()  # Inspect: the exact existing bordered/tinted chip
-        assert restored["border"] != "rgba(0, 0, 0, 0)"
-        assert restored["bg"] != "rgba(0, 0, 0, 0)"
-        assert restored["pad"] == "4px 12px 4px 8px"
-        assert page.locator("#outcomeChip").get_attribute("aria-hidden") == "false"
+        insp = chip()
+        assert insp == pres  # same computed style across the mode switch
+        assert page.locator("#outcomeChip").get_attribute("aria-hidden") is None
         browser.close()
 
 
@@ -1733,7 +1673,7 @@ def test_probe_boundary_status_vs_content_availability(tmp_path):
         assert "UNKNOWN" in page.locator("#sharedSourceStatus").text_content()
         # drawer summary reads as the probe boundary
         summary = page.locator("#sharedSourceDrawerSummary").text_content()
-        assert "Source Probe" in summary and "your function code" in summary
+        assert "Application source" in summary  # #128: identical title both modes
         browser.close()
 
 
@@ -1782,9 +1722,9 @@ def test_probe_boundary_responsive_360(tmp_path):
         assert vp["canvas"] >= 660
         rail = page.evaluate(
             """() => getComputedStyle(
-                 document.querySelector('#sharedSourceDrawer'), '::before').left"""
+                 document.querySelector('#sharedSourceDrawer'), '::before').content"""
         )
-        assert rail.endswith("px")  # JS-positioned rail stays inside the visible column
+        assert rail == "none"  # #128: decorative rail removed — shared source identical
         browser.close()
 
 
@@ -1895,16 +1835,16 @@ def test_shared_layers_mode_switch_preserves_nodes_and_state(tmp_path):
         assert after["errorKind"] == before["errorKind"]
         assert after["sourceText"] == before["sourceText"]
         assert after["open"] == before["open"]
-        assert after["title"] == "Application source"  # framing text follows mode
+        assert after["title"] == "Application source"  # #128: constant in both modes
         page.locator("#presentationTab").click()
         page.wait_for_timeout(150)
         assert (
-            page.locator("#sharedSourceTitle").text_content() == "Source Probe · your function code"
-        )
+            page.locator("#sharedSourceTitle").text_content() == "Application source"
+        )  # #128: never mutated by the mode switch
         browser.close()
 
 
-def test_shared_layers_presentation_compact_evidence(tmp_path):
+def test_shared_layers_evidence_identical_across_modes(tmp_path):
     playwright = pytest.importorskip("playwright.sync_api")
     html = _viewer(tmp_path, "success")
     with playwright.sync_playwright() as pw:
@@ -1932,16 +1872,13 @@ def test_shared_layers_presentation_compact_evidence(tmp_path):
             )
 
         pres = evidence()
-        assert pres["raw"] == "none"  # low-level detail recedes in Presentation
-        assert pres["rawLabel"] == "none"
-        assert pres["name"] != "none"  # semantic event stays
-        assert pres["meta"]  # elapsed/confidence rows stay
+        assert pres["raw"] != "none"  # #128: raw log visible in BOTH modes
+        assert pres["name"] != "none"
+        assert pres["meta"]  # elapsed/confidence rows always render
         page.locator("#inspectTab").click()
         page.wait_for_timeout(200)
         insp = evidence()
-        assert insp["raw"] != "none"  # Inspect shows full forensic detail
-        assert insp["detailId"] != "none" if insp["detailId"] != "absent" else True
-        assert insp["name"] != "none"
+        assert insp == pres  # identical density — no mode-conditioned evidence
         browser.close()
 
 
@@ -2034,4 +1971,138 @@ def test_shared_layers_responsive_grid(tmp_path):
             assert got["scrollW"] == width  # no page overflow at any width
             assert got["gutter"] <= 1  # same gutter as the active shell
             page.close()
+        browser.close()
+
+
+# --------------------------------------------------------------------------
+# #128 — STRICT shared-layer parity: only the central canvas differs. At the
+# same selected event, every shared layer holds the same node references,
+# normalized text, computed styles and own dimensions across mode switches.
+# --------------------------------------------------------------------------
+
+PARITY_SNAP = """() => {
+  const norm = s => s.replace(/\\s+/g, ' ').trim();
+  const style = el => {
+    const cs = getComputedStyle(el);
+    return [cs.borderTopColor, cs.backgroundColor, cs.padding, cs.font,
+            cs.color].join('|');
+  };
+  const dim = el => {
+    const r = el.getBoundingClientRect();
+    return Math.round(r.width) + 'x' + Math.round(r.height);
+  };
+  const q = s => document.querySelector(s);
+  const transport = q('#sharedTransportLayer .pres-transport').offsetParent !== null
+    ? q('#sharedTransportLayer .pres-transport')
+    : q('#sharedTransportLayer .replay-controls');
+  return {
+    headerChip: [norm(q('#outcomeChip').textContent), style(q('#outcomeChip')),
+                 q('#outcomeChip').getAttribute('aria-hidden')],
+    loader: norm(q('#traceLoaderSummary').textContent),
+    confidence: [norm(q('#confidenceBanner').textContent),
+                 dim(q('#confidenceBanner')), style(q('#confidenceBanner'))],
+    transportText: norm(transport.textContent),
+    transportDim: dim(transport),
+    transportButtons: [...transport.querySelectorAll('button')].map(b =>
+      [b.textContent, b.disabled, b.getAttribute('aria-pressed')].join(':')),
+    evidenceText: [norm(q('#stepDetail').textContent),
+                   norm(q('#errorSummary').textContent),
+                   norm(q('#stackPanel').textContent)],
+    evidenceDim: [dim(q('#stepDetail')), dim(q('#errorSummary')), dim(q('#stackPanel'))],
+    evidenceStyle: [style(q('#stepDetail')), style(q('#errorSummary')),
+                    style(q('#stackPanel'))],
+    source: [norm(q('#sharedSourceTitle').textContent),
+             norm(q('#sharedSourceStatus').textContent),
+             norm(q('#sharedSourceFileLabel').textContent),
+             q('#sharedSourceDrawer').open],
+    sourceDim: dim(q('#sharedSourceDrawer')),
+    sourceStyle: style(q('#sharedSourceDrawer')),
+    footer: norm(q('.app-footer').textContent),
+    railRemoved: getComputedStyle(q('#sharedSourceDrawer'), '::before').content === 'none',
+  };
+}"""
+
+
+def test_strict_parity_all_shared_layers(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "invocation-fail")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1200})
+        page.goto(html.as_uri())
+        for _ in range(3):
+            page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(200)
+        nodes = page.evaluate(
+            """() => ['outcomeChip', 'traceLoader', 'confidenceBanner',
+              'sharedTransportLayer', 'stepDetail', 'errorSummary',
+              'stackPanel', 'sharedSourceDrawer', 'sourcePanel']
+              .map(id => document.getElementById(id) !== null)"""
+        )
+        assert all(nodes)
+        pres = page.evaluate(PARITY_SNAP)
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(300)
+        insp = page.evaluate(PARITY_SNAP)
+        for key in pres:
+            assert insp[key] == pres[key], key  # strict parity per layer
+        assert pres["railRemoved"]  # decorative rail gone in BOTH modes
+        browser.close()
+
+
+def test_strict_parity_replay_projection(tmp_path):
+    playwright = pytest.importorskip("playwright.sync_api")
+    html = _viewer(tmp_path, "success")
+    with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        page.goto(html.as_uri())
+        for _ in range(2):
+            page.locator("#presentationNextBtn").click()
+        page.wait_for_timeout(200)
+
+        def visible_projection():
+            return page.evaluate(
+                """() => {
+                  const layer = document.getElementById('sharedTransportLayer');
+                  const group = layer.querySelector('.pres-transport').offsetParent !== null
+                    ? layer.querySelector('.pres-transport')
+                    : layer.querySelector('.replay-controls');
+                  const norm = s => s.replace(/\\s+/g, ' ').trim();
+                  const r = group.getBoundingClientRect();
+                  return {
+                    text: norm(group.textContent),
+                    /* ids differ by design (back-compat duplicate groups);
+                       parity is over tag/order only */
+                    roles: [...group.children].map(c => c.tagName).join(','),
+                    buttons: [...group.querySelectorAll('button')].map(b =>
+                      [b.textContent, b.disabled, b.getAttribute('aria-pressed'),
+                       Math.round(b.getBoundingClientRect().width) + 'x' +
+                       Math.round(b.getBoundingClientRect().height)].join(':')),
+                    dim: Math.round(r.width) + 'x' + Math.round(r.height),
+                  };
+                }"""
+            )
+
+        pres = visible_projection()
+        assert "t +" in pres["text"] and "Step 2 of 7" in pres["text"]
+        page.locator("#inspectTab").click()
+        page.wait_for_timeout(200)
+        insp = visible_projection()
+        for key in pres:
+            assert insp[key] == pres[key], key  # pixel/text/control parity
+        # mid-play parity: the clock advances identically in both projections
+        page.locator("#replayPlayBtn").click()
+        page.wait_for_timeout(400)
+        clocks = page.evaluate(
+            """() => [
+              document.getElementById('playheadClock').textContent,
+              document.getElementById('presentationClock').textContent]"""
+        )
+        page.evaluate("window.Funcviz.pause()")
+        assert clocks[0] == clocks[1] and clocks[0].startswith("t +")
+        paused_insp = visible_projection()  # fresh snapshot in Inspect (paused)
+        page.locator("#presentationTab").click()
+        page.wait_for_timeout(150)
+        assert visible_projection() == paused_insp  # parity at the same state
         browser.close()


### PR DESCRIPTION
## Summary
- show the full Trace confidence boundary counts + Details in both modes; remove compact Presentation legend
- make the header outcome identical and accessible in both modes
- make both replay projections pixel/text/control equivalent, including clock and step/status
- expose the same full Step Detail/Error/Call Stack density in both modes
- use the same `Application source` title, style, status, content, and open state in both modes
- remove source/evidence/header mode styling and stale mode-specific comments
- retain only the intentional central difference: Presentation sequence/story/progress vs Inspect durations/timeline

## Verification
- standard 162 passed / 59 skipped; Ruff, LSP, traces, Pages artifact
- Chromium viewer E2E 58 passed; Pages smoke 1
- 1440/360 shared layers: exact normalized text, dimensions, styles, a11y, and DOM refs across switches
- all golden Presentation/Inspect walkthroughs console/network0
- Oracle 94/100, no blockers

Closes #128